### PR TITLE
Describe a known build issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Example:
 cmake -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=/path/to/installed/spirv/translator ../opencl-clang
 ```
 
+There is a known issue (linker crash) for this kind of build on Ubuntu 16.04 Xenial.
+In this case the following cmake option should fix it:
+```
+-DLLVM_NO_DEAD_STRIP=ON
+```
+
 Installation directory of SPIR-V Translator is expected to contain the
 following files:
 ```


### PR DESCRIPTION
When we build opencl-clang on Ubuntu 16.04 Xenial with pre-built LLVM and
pre-built SPIR-V library using GNU ld linker (binutils 2.26.1) we can see
segmentaion fault at linking. This is probably a bug in the linker.
The crash appears because '--gc-sections' linker option is added by
add_link_opts function in AddLLVM.cmake. Cmake doesn't use this option if
LLVM_NO_DEAD_STRIP is ON