### PR TITLE
Add -Werror=implicit-function-declaration option.

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -213,6 +213,13 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
   // extension should be enabled by passing a '-cl-ext' option in pszOptionsEx.
   effectiveArgs.push_back("-cl-ext=-all");
 
+  // OpenCL v2.0 s6.9.u - Implicit function declaration is not supported.
+  // Behavior of clang is changed and now there is only warning about
+  // implicit function declarations. To be more user friendly and avoid
+  // unexpected indirect function calls in IR, let's force this warning to
+  // error.
+  effectiveArgs.push_back("-Werror=implicit-function-declaration");
+
   // add the extended options verbatim
   std::back_insert_iterator<ArgsVector> it(std::back_inserter(effectiveArgs));
   quoted_tokenize(it, pszOptionsEx, " \t", '"', '\x00');


### PR DESCRIPTION
This patch restores warning to error back after the following commit:

> commit 39691fddaf4f5199ecf9960ae3059943d59f659b
> Author: Richard Smith <richard-llvm@metafoo.co.uk>
> Date:   Wed Oct 4 01:58:22 2017 +0000
>
>   We allow implicit function declarations as an extension in all C
>   dialects. Remove OpenCL special case.
>
>   git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@314872
>   91177308-0d34-0410-b5e6-96231b3b80d8