### PR TITLE
opencl-clang will not compile for llvm < 9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ make all -j`nproc`
 
 ##### Preferred LLVM version
 
-By default, Common clang's cmake script is searching for LLVM 8.0.0. You can
+By default, Common clang's cmake script is searching for LLVM 9.0.0. You can
 override target version of LLVM by using `PREFERRED_LLVM_VERSION` cmake option:
 
 Example:
 ```
-cmake -DPREFERRED_LLVM_VERSION="7.0.1" ../opencl-clang
+cmake -DPREFERRED_LLVM_VERSION="9.0.0" ../opencl-clang
 ```
 
 ##### Custom LLVM installation


### PR DESCRIPTION
Recent changes to use llvm vfs and SPIR-V api changes breaks compatibility with llvm < 9.