### PR TITLE
Fix for attaching opencl-c-base.h into libopencl-clang.so ress

### DIFF
--- a/cl_headers/CMakeLists.txt
+++ b/cl_headers/CMakeLists.txt
@@ -18,11 +18,13 @@ else(USE_PREBUILT_LLVM)
     set(OPENCL_HEADERS_DIR "${CLANG_SOURCE_DIR}/lib/Headers")
 endif(USE_PREBUILT_LLVM)
 copy_file(${OPENCL_HEADERS_DIR}/opencl-c.h opencl-c.h)
+copy_file(${OPENCL_HEADERS_DIR}/opencl-c-base.h opencl-c-base.h)
 
 add_custom_target (
     opencl.headers.target
     DEPENDS
     opencl-c.h
+    opencl-c-base.h
 )
 
 
@@ -39,8 +41,10 @@ if(WIN32)
     list(APPEND CL_HEADERS_SRC OpenCL.rc)
 else()
     pack_to_obj(opencl-c.h           opencl-c.h.cpp           "PCM_OPENCL_C_H")
+    pack_to_obj(opencl-c-base.h      opencl-c-base.h.cpp      "PCM_OPENCL_C_BASE_H")
     list(APPEND CL_HEADERS_SRC
-         opencl-c.h.cpp
+      opencl-c.h.cpp
+      opencl-c-base.h.cpp
     )
 endif()
 

--- a/cl_headers/OpenCL.rc
+++ b/cl_headers/OpenCL.rc
@@ -12,3 +12,4 @@ END
 //
 
 OPENCL_C_H                PCM   "opencl-c.h"
+OPENCL_C_BASE_H           PCM   "opencl-c-base.h"

--- a/cl_headers/resource.h
+++ b/cl_headers/resource.h
@@ -20,5 +20,6 @@ Copyright (c) Intel Corporation (2009-2017).
 #define __RESOURCE__
 
 #define OPENCL_C_H             "OPENCL_C_H"
+#define OPENCL_C_BASE_H        "OPENCL_C_BASE_H"
 
 #endif /* __RESOURCE__ */

--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -115,6 +115,7 @@ void CommonClangInitialize() {
 static bool GetHeaders(std::vector<Resource> &Result) {
   struct {const char *ID; const char *Name;} Headers[] = {
     {OPENCL_C_H,             "opencl-c.h"},
+    {OPENCL_C_BASE_H,        "opencl-c-base.h"},
   };
 
   Result.clear();

--- a/common_clang.map
+++ b/common_clang.map
@@ -7,6 +7,7 @@ global:
    Link;
    GetKernelArgInfo;
    PCM_OPENCL_C_H*;
+   PCM_OPENCL_C_BASE_H*;
  };
 local: *;
 };

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -198,6 +198,7 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
 
   effectiveArgs.push_back("-include");
   effectiveArgs.push_back("opencl-c.h");
+  effectiveArgs.push_back("opencl-c-base.h");
 
   // Don't optimize in the frontend
   // clang defaults to -O0, and in that mode, does not produce IR that is

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -198,7 +198,6 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
 
   effectiveArgs.push_back("-include");
   effectiveArgs.push_back("opencl-c.h");
-  effectiveArgs.push_back("opencl-c-base.h");
 
   // Don't optimize in the frontend
   // clang defaults to -O0, and in that mode, does not produce IR that is


### PR DESCRIPTION
After that commit:
https://github.com/llvm-mirror/clang/commit/1d6967454f5879df81398eca7277f3bf32c47dbd

opencl-c.h now is splitted into opencl-c.h and opencl-c-base.h
libopencl-clang.so needs to have the second header too.