### PR TITLE
[PATCH] Add Fix-support-for-cl_khr_mipmap_image_writes.patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,10 @@ set(TARGET_NAME ${COMMON_CLANG_LIBRARY_NAME}${BUILD_PLATFORM} )
 if(NOT USE_PREBUILT_LLVM)
     set(TARGET_BRANCH "ocl-open-80")
     set(CLANG_SOURCE_DIR ${LLVM_SOURCE_DIR}/tools/clang)
-    set(CLANG_BASE_REVISION 2e4c9c5fc864c2c432e4c262a67c42d824b265c6)
+    set(CLANG_BASE_REVISION release_80)
 
     set(SPIRV_SOURCE_DIR ${LLVM_SOURCE_DIR}/projects/llvm-spirv)
-    set(SPIRV_BASE_REVISION bb96964181723d32dfe61ef7780dcbdf0f931ccf)
+    set(SPIRV_BASE_REVISION llvm_release_80)
 
     apply_patches(${CLANG_SOURCE_DIR}
                   ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang

--- a/patches/clang/0005-Fix-support-for-cl_khr_mipmap_image_writes.patch
+++ b/patches/clang/0005-Fix-support-for-cl_khr_mipmap_image_writes.patch
@@ -1,0 +1,110 @@
+From 8e988b0da81d4113bc8a7891e62afad16d396b19 Mon Sep 17 00:00:00 2001
+From: Alexey Sotkin <alexey.sotkin@intel.com>
+Date: Mon, 27 Jan 2020 12:25:03 +0300
+Subject: [PATCH] Fix support for cl_khr_mipmap_image_writes
+
+Text of the extension is available here:
+https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_khr_mipmap_image.asciidoc
+
+Patch by Ilya Mashkov
+
+Differential Revision: https://reviews.llvm.org/D71460
+---
+ include/clang/Basic/OpenCLExtensions.def |  1 +
+ lib/Headers/opencl-c.h                   | 18 ++++++++++--------
+ test/SemaOpenCL/extension-version.cl     | 12 ++++++++++++
+ 3 files changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/include/clang/Basic/OpenCLExtensions.def b/include/clang/Basic/OpenCLExtensions.def
+index 5e7d2cb..c0ba156 100644
+--- a/include/clang/Basic/OpenCLExtensions.def
++++ b/include/clang/Basic/OpenCLExtensions.def
+@@ -71,6 +71,7 @@ OPENCLEXT_INTERNAL(cl_khr_spir, 120, ~0U)
+ OPENCLEXT_INTERNAL(cl_khr_egl_event, 200, ~0U)
+ OPENCLEXT_INTERNAL(cl_khr_egl_image, 200, ~0U)
+ OPENCLEXT_INTERNAL(cl_khr_mipmap_image, 200, ~0U)
++OPENCLEXT_INTERNAL(cl_khr_mipmap_image_writes, 200, ~0U)
+ OPENCLEXT_INTERNAL(cl_khr_srgb_image_writes, 200, ~0U)
+ OPENCLEXT_INTERNAL(cl_khr_subgroups, 200, ~0U)
+ OPENCLEXT_INTERNAL(cl_khr_terminate_context, 200, ~0U)
+diff --git a/lib/Headers/opencl-c.h b/lib/Headers/opencl-c.h
+index 3d3dfb7..514c710 100644
+--- a/lib/Headers/opencl-c.h
++++ b/lib/Headers/opencl-c.h
+@@ -15032,7 +15032,7 @@ void __ovld write_imagef(write_only image2d_array_depth_t image, int4 coord, flo
+ 
+ // OpenCL Extension v2.0 s9.18 - Mipmaps
+ #if __OPENCL_C_VERSION__ >= CL_VERSION_2_0
+-#ifdef cl_khr_mipmap_image
++#if defined(cl_khr_mipmap_image_writes)
+ void __ovld write_imagef(write_only image1d_t image, int coord, int lod, float4 color);
+ void __ovld write_imagei(write_only image1d_t image, int coord, int lod, int4 color);
+ void __ovld write_imageui(write_only image1d_t image, int coord, int lod, uint4 color);
+@@ -15049,15 +15049,16 @@ void __ovld write_imagef(write_only image2d_array_t image_array, int4 coord, int
+ void __ovld write_imagei(write_only image2d_array_t image_array, int4 coord, int lod, int4 color);
+ void __ovld write_imageui(write_only image2d_array_t image_array, int4 coord, int lod, uint4 color);
+ 
+-void __ovld write_imagef(write_only image2d_depth_t image, int2 coord, int lod, float color);
+-void __ovld write_imagef(write_only image2d_array_depth_t image, int4 coord, int lod, float color);
++void __ovld write_imagef(write_only image2d_depth_t image, int2 coord, int lod, float depth);
++void __ovld write_imagef(write_only image2d_array_depth_t image, int4 coord, int lod, float depth);
+ 
+ #ifdef cl_khr_3d_image_writes
+ void __ovld write_imagef(write_only image3d_t image, int4 coord, int lod, float4 color);
+ void __ovld write_imagei(write_only image3d_t image, int4 coord, int lod, int4 color);
+ void __ovld write_imageui(write_only image3d_t image, int4 coord, int lod, uint4 color);
+-#endif
+-#endif //cl_khr_mipmap_image
++#endif //cl_khr_3d_image_writes
++
++#endif //defined(cl_khr_mipmap_image_writes)
+ #endif //__OPENCL_C_VERSION__ >= CL_VERSION_2_0
+ 
+ // Image write functions for half4 type
+@@ -15106,7 +15107,7 @@ void __ovld write_imagef(read_write image2d_array_depth_t image, int4 coord, flo
+ #endif //cl_khr_depth_images
+ 
+ #if __OPENCL_C_VERSION__ >= CL_VERSION_2_0
+-#ifdef cl_khr_mipmap_image
++#if defined(cl_khr_mipmap_image_writes)
+ void __ovld write_imagef(read_write image1d_t image, int coord, int lod, float4 color);
+ void __ovld write_imagei(read_write image1d_t image, int coord, int lod, int4 color);
+ void __ovld write_imageui(read_write image1d_t image, int coord, int lod, uint4 color);
+@@ -15130,8 +15131,9 @@ void __ovld write_imagef(read_write image2d_array_depth_t image, int4 coord, int
+ void __ovld write_imagef(read_write image3d_t image, int4 coord, int lod, float4 color);
+ void __ovld write_imagei(read_write image3d_t image, int4 coord, int lod, int4 color);
+ void __ovld write_imageui(read_write image3d_t image, int4 coord, int lod, uint4 color);
+-#endif
+-#endif //cl_khr_mipmap_image
++#endif //cl_khr_3d_image_writes
++
++#endif //cl_khr_mipmap_image_writes
+ #endif //__OPENCL_C_VERSION__ >= CL_VERSION_2_0
+ 
+ // Image write functions for half4 type
+diff --git a/test/SemaOpenCL/extension-version.cl b/test/SemaOpenCL/extension-version.cl
+index d976cfb..dcac956 100644
+--- a/test/SemaOpenCL/extension-version.cl
++++ b/test/SemaOpenCL/extension-version.cl
+@@ -243,6 +243,18 @@
+ #pragma OPENCL EXTENSION cl_khr_mipmap_image : enable
+ 
+ #if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
++#ifndef cl_khr_mipmap_image_writes
++#error "Missing cl_khr_mipmap_image_writes define"
++#endif
++#else
++#ifdef cl_khr_mipmap_image_writes
++#error "Incorrect cl_khr_mipmap_image_writes define"
++#endif
++// expected-warning@+2{{unsupported OpenCL extension 'cl_khr_mipmap_image_writes' - ignoring}}
++#endif
++#pragma OPENCL EXTENSION cl_khr_mipmap_image_writes : enable
++
++#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
+ #ifndef cl_khr_srgb_image_writes
+ #error "Missing cl_khr_srgb_image_writes define"
+ #endif
+-- 
+2.7.4
+

--- a/patches/spirv/0002-Remove-extra-semicolon.patch
+++ b/patches/spirv/0002-Remove-extra-semicolon.patch
@@ -1,4 +1,4 @@
-From a2c093c8db7b4e3a5612d0fcce9e4fd1756d6e4b Mon Sep 17 00:00:00 2001
+From 194e699aef7850b189bdb5816444f44dc467d6a8 Mon Sep 17 00:00:00 2001
 From: Alexey Sotkin <alexey.sotkin@intel.com>
 Date: Mon, 5 Aug 2019 18:18:01 +0300
 Subject: [PATCH] Remove extra semicolon
@@ -8,12 +8,12 @@ Subject: [PATCH] Remove extra semicolon
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/lib/SPIRV/libSPIRV/SPIRVEnum.h b/lib/SPIRV/libSPIRV/SPIRVEnum.h
-index c93a484..3a071e7 100644
+index 2d7c870..9260685 100644
 --- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
 +++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
-@@ -124,7 +124,7 @@ template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
-   add(SPV_INTEL_device_side_avc_motion_estimation,
+@@ -121,7 +121,7 @@ template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
        "SPV_INTEL_device_side_avc_motion_estimation");
+   add(SPV_INTEL_media_block_io, "SPV_INTEL_media_block_io");
    add(SPV_KHR_no_integer_wrap_decoration, "SPV_KHR_no_integer_wrap_decoration");
 -};
 +}


### PR DESCRIPTION
Also update CMakeLists.txt to set base revision for patches to branch
names instead of fixed commits hashes.
Also update Remove-extra-semicolon.patch patch to avoid warning messages
when it is being applied.

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>