### PR TITLE
Add ResetAllOptionOccurrences before creating CompilerInvocation

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -245,6 +245,9 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
     compiler->createFileManager(OverlayFS);
     compiler->createSourceManager(compiler->getFileManager());
 
+    // Calling ResetAllOptionOccurrences as WA for issue from here:
+    // https://reviews.llvm.org/D66324?id=219733#1680231
+    llvm::cl::ResetAllOptionOccurrences();
     // Create compiler invocation from user args before trickering with it
     clang::CompilerInvocation::CreateFromArgs(compiler->getInvocation(),
                                               optionsParser.args(), *Diags);


### PR DESCRIPTION
After this change:
https://github.com/llvm/llvm-project/commit/7bdad08429411e7d0ecd58cd696b1efe3cff309e
To be more precise, in this line:
https://github.com/llvm/llvm-project/blob/d2a710ea784eea43c63e3831224de6355f1e4a6f/clang/lib/Frontend/CompilerInvocation.cpp#L3587

We have a problem during second compilation of user kernel via opencl-clang in the same process. When we hit this place two times - it will abort the compilation, because we are trying to assign the same flag twice which is wrong.

message error:
clang (LLVM option parsing): for the --pgo-warn-misexpect option: may only occur zero or one times!