### PR TITLE
Building in-tree with LLVM 10.0 with the LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ link_directories(
 
 set(OPENCL_CLANG_LINK_LIBS ${CMAKE_DL_LIBS})
 
-if(NOT LLVMSPIRVLib IN_LIST LLVM_AVAILABLE_LIBS)
+if(NOT LLVMSPIRVLib IN_LIST LLVM_AVAILABLE_LIBS OR (USE_PREBUILT_LLVM AND LLVM_LINK_LLVM_DYLIB))
   # SPIRV-LLVM-Translator is not included into LLVM as a component.
   # So, we need to list it here explicitly as an external library
   list(APPEND OPENCL_CLANG_LINK_LIBS LLVMSPIRVLib)


### PR DESCRIPTION
Failed to link with the LLVMSPIRVLib library.

Add an explicit dependency to force the correct build order and linking.

Reference:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/a6d4ccf082858e63e139ca06c02a071c343d2657

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>