### PR TITLE
Build llvm spirv translator from source for opencl-clang CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,25 +21,19 @@ env:
     - BUILD_TYPE=Release
     - BUILD_TYPE=Debug
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-      - ubuntu-toolchain-r-test
-    packages:
-      - llvm-8-tools
-      - llvm-8-dev
-      - libclang-8-dev
 
 install:
-  - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 spirv-llvm-translator
+  - git clone https://github.com/llvm-mirror/llvm.git -b release_80
+  - cd ./llvm/tools
+  - git clone https://github.com/llvm-mirror/clang.git -b release_80
+  - cd ../projects
+  - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 llvm-spirv
+  - git clone https://github.com/intel/opencl-clang.git -b ocl-open-80
 
 compiler:
   - gcc
-  - clang
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=./spirv-llvm-translator -DCMAKE_INSTALL_PREFIX=./install ..
-  - make install
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON --DCMAKE_INSTALL_PREFIX=./install ../llvm
+  - make -j`nproc`

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - cd ../projects
   - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 llvm-spirv
   - git clone https://github.com/intel/opencl-clang.git -b ocl-open-80
+  - cd ../..
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ dist: xenial
 
 git:
   depth: 1
-  quiet: true
 
 branches:
   only:
@@ -21,20 +20,28 @@ env:
     - BUILD_TYPE=Release
     - BUILD_TYPE=Debug
 
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+      - ubuntu-toolchain-r-test
+    packages:
+      - llvm-8-tools
+      - llvm-8-dev
+      - libclang-8-dev
 
 install:
-  - git clone https://github.com/llvm-mirror/llvm.git -b release_80
-  - cd ./llvm/tools
-  - git clone https://github.com/llvm-mirror/clang.git -b release_80
-  - cd ../projects
-  - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 llvm-spirv
-  - git clone https://github.com/intel/opencl-clang.git -b ocl-open-80
-  - cd ../..
+  - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 spirv-llvm-translator
+  - mkdir spirv-llvm-translator/build && cd spirv-llvm-translator/build
+  - cmake .. -DCMAKE_INSTALL_PREFIX=./install && make -j`nproc` && make install
+  - cd ../../
 
 compiler:
   - gcc
+  - clang
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON --DCMAKE_INSTALL_PREFIX=./install ../llvm
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=../spirv-llvm-translator -DSPIRV_SOURCE_DIR=../spirv-llvm-translator/build/install ../
   - make -j`nproc`

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ addons:
 install:
   - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 spirv-llvm-translator
   - mkdir spirv-llvm-translator/build && cd spirv-llvm-translator/build
-  - cmake .. -DCMAKE_INSTALL_PREFIX=./install && make -j`nproc` && make install
+  - cmake .. -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON -DLLVM_BUILD_TOOLS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+  - make -j`nproc` && make install
   - cd ../../
 
 compiler:
@@ -43,5 +44,5 @@ compiler:
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=../spirv-llvm-translator/build/install ../
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=${TRAVIS_BUILD_DIR}/spirv-llvm-translator/build/install ../
   - make -j`nproc`

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ addons:
 
 install:
   - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 spirv-llvm-translator
-  - mkdir spirv-llvm-translator/build && cd spirv-llvm-translator/build
+  - cd spirv-llvm-translator
+  - for patch in `ls ../patches/spirv/*.patch`; do echo $patch; git apply $patch; done
+  - mkdir build && cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON -DLLVM_BUILD_TOOLS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
   - make -j`nproc` && make install
   - cd ../../

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
 
 # Use Ubuntu 16.04 LTS (Xenial) as the Linux testing environment.
 dist: xenial
-sudo: false
 
 git:
   depth: 1
+  quiet: true
 
 branches:
   only:
@@ -33,10 +33,7 @@ addons:
       - libclang-8-dev
 
 install:
-  - export TAG=v8.0.1-3
-  - export TARBALL=SPIRV-LLVM-Translator-${TAG}-linux-${BUILD_TYPE}.zip
-  - wget https://github.com/KhronosGroup/SPIRV-LLVM-Translator/releases/download/${TAG}/${TARBALL} -O /tmp/${TARBALL}
-  - unzip /tmp/${TARBALL} -d spirv-llvm-translator
+  - git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git -b llvm_release_80 spirv-llvm-translator
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,5 @@ compiler:
 
 script:
   - mkdir build && cd build
-  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=../spirv-llvm-translator -DSPIRV_SOURCE_DIR=../spirv-llvm-translator/build/install ../
+  - cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DLLVM_NO_DEAD_STRIP=ON -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=../spirv-llvm-translator/build/install ../
   - make -j`nproc`


### PR DESCRIPTION
The source code should be used by travis CI tests, since it has latest changes for spirv translator.