### PR TITLE
Add llvm patch to fix ManagedStatic memleak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,11 @@ if(NOT USE_PREBUILT_LLVM)
 
     if(NOT LLVM_EXTERNAL_CLANG_SOURCE_DIR)
         set(CLANG_SOURCE_DIR ${LLVM_SOURCE_DIR}/tools/clang)
+        set(LLVM_BASE_REVISION release_90)
         set(CLANG_BASE_REVISION release_90)
     elseif(EXISTS "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/CMakeLists.txt")
         set(CLANG_SOURCE_DIR "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}")
+        set(LLVM_BASE_REVISION release/9.x)
         set(CLANG_BASE_REVISION release/9.x)
     endif()
     if(EXISTS ${CLANG_SOURCE_DIR})
@@ -123,6 +125,10 @@ if(NOT USE_PREBUILT_LLVM)
     set(SPIRV_BASE_REVISION llvm_release_90)
     set(TARGET_BRANCH "ocl-open-90")
 
+    apply_patches(${LLVM_SOURCE_DIR}
+                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+                  ${LLVM_BASE_REVISION}
+                  ${TARGET_BRANCH})
     apply_patches(${CLANG_SOURCE_DIR}
                   ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang
                   ${CLANG_BASE_REVISION}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This can be done using the following commands:
 ```
 cd <workspace>
 git clone https://github.com/llvm-mirror/llvm.git -b release_90
-cd tools
+cd <workspace>/llvm/tools
 git clone https://github.com/llvm-mirror/clang.git -b release_90
 cd <workspace>/llvm/projects
 git clone https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git llvm-spirv -b llvm_release_90

--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -87,7 +87,12 @@ static llvm::sys::Mutex lazyCCInitMutex;
 
 static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileMutex;
 
-void CommonClangTerminate() { llvm::llvm_shutdown(); }
+void CommonClangTerminate() {
+  llvm::llvm_shutdown();
+#ifndef USE_PREBUILT_LLVM
+  llvm::deleteManagedStaticMutex();
+#endif
+}
 
 // This function mustn't be invoked from a static object constructor,
 // from a DllMain function (Windows specific), or from a function

--- a/patches/llvm/0001-Adding-llvm-deleteManagedStaticMutex.patch
+++ b/patches/llvm/0001-Adding-llvm-deleteManagedStaticMutex.patch
@@ -1,0 +1,46 @@
+From 7e1048625f90371cf76baf040310a7cfa1203555 Mon Sep 17 00:00:00 2001
+From: Viktoria Maksimova <viktoria.maksimova@intel.com>
+Date: Wed, 9 Sep 2020 10:11:01 +0800
+Subject: [PATCH] Adding llvm::deleteManagedStaticMutex
+
+---
+ include/llvm/Support/ManagedStatic.h | 8 ++++++++
+ lib/Support/ManagedStatic.cpp        | 5 +++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/include/llvm/Support/ManagedStatic.h b/include/llvm/Support/ManagedStatic.h
+index e65bb051f18..14ca50b8f7e 100644
+--- a/include/llvm/Support/ManagedStatic.h
++++ b/include/llvm/Support/ManagedStatic.h
+@@ -107,6 +107,14 @@ public:
+ /// llvm_shutdown - Deallocate and destroy all ManagedStatic variables.
+ void llvm_shutdown();
+ 
++/// Purpose of this function is to free memory allocated for ManagedStaticMutex.
++/// One might want to do that to avoid memory leaks in case LLVM is loaded as a
++/// shared library (or dll) at runtime.
++/// This function is not thread safe and should be called only if there are no
++/// threads which are using the mutex now or will use the mutex in the future.
++/// This means deleteManagedStaticMutex can be called only after llvm_shutdown.
++void deleteManagedStaticMutex();
++
+ /// llvm_shutdown_obj - This is a simple helper class that calls
+ /// llvm_shutdown() when it is destroyed.
+ struct llvm_shutdown_obj {
+diff --git a/lib/Support/ManagedStatic.cpp b/lib/Support/ManagedStatic.cpp
+index 28ceb1a70e4..5c2d03d0e5f 100644
+--- a/lib/Support/ManagedStatic.cpp
++++ b/lib/Support/ManagedStatic.cpp
+@@ -82,3 +82,8 @@ void llvm::llvm_shutdown() {
+   while (StaticList)
+     StaticList->destroy();
+ }
++
++void llvm::deleteManagedStaticMutex() {
++  assert(StaticList == nullptr && "llvm_shutdown() must be called first!");
++  delete ManagedStaticMutex;
++}
+\ No newline at end of file
+-- 
+2.18.1
+


### PR DESCRIPTION
Patch is downloaded from https://reviews.llvm.org/D52425
It can fix memory leak of ManagedStatic.