### PR TITLE
Add llvm patch to fix ManagedStatic memleak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,11 @@ set(TARGET_NAME ${COMMON_CLANG_LIBRARY_NAME}${BUILD_PLATFORM} )
 if(NOT USE_PREBUILT_LLVM)
 
     if(NOT LLVM_EXTERNAL_CLANG_SOURCE_DIR)
+        set(LLVM_BASE_REVISION release_10)
         set(CLANG_SOURCE_DIR ${LLVM_SOURCE_DIR}/tools/clang)
         set(CLANG_BASE_REVISION release_10)
     elseif(EXISTS "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/CMakeLists.txt")
+        set(LLVM_BASE_REVISION release/10.x)
         set(CLANG_SOURCE_DIR "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}")
         set(CLANG_BASE_REVISION release/10.x)
     endif()
@@ -122,6 +124,10 @@ if(NOT USE_PREBUILT_LLVM)
     set(SPIRV_BASE_REVISION llvm_release_100)
     set(TARGET_BRANCH "ocl-open-100")
 
+    apply_patches(${LLVM_SOURCE_DIR}
+                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+                  ${LLVM_BASE_REVISION}
+                  ${TARGET_BRANCH})
     apply_patches(${CLANG_SOURCE_DIR}
                   ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang
                   ${CLANG_BASE_REVISION}

--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -87,7 +87,12 @@ static llvm::sys::Mutex lazyCCInitMutex;
 
 static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileMutex;
 
-void CommonClangTerminate() { llvm::llvm_shutdown(); }
+void CommonClangTerminate() {
+  llvm::llvm_shutdown();
+#ifndef USE_PREBUILT_LLVM
+  llvm::deleteManagedStaticMutex();
+#endif
+}
 
 // This function mustn't be invoked from a static object constructor,
 // from a DllMain function (Windows specific), or from a function

--- a/patches/llvm/0001-Adding-llvm-deleteManagedStaticMutex.patch
+++ b/patches/llvm/0001-Adding-llvm-deleteManagedStaticMutex.patch
@@ -1,0 +1,46 @@
+From be6aa9ff5151288aef2fc5022c4303a42f1690f9 Mon Sep 17 00:00:00 2001
+From: Viktoria Maksimova <viktoria.maksimova@intel.com>
+Date: Wed, 9 Sep 2020 10:46:17 +0800
+Subject: [PATCH] Adding llvm::deleteManagedStaticMutex
+
+---
+ llvm/include/llvm/Support/ManagedStatic.h | 8 ++++++++
+ llvm/lib/Support/ManagedStatic.cpp        | 5 +++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/llvm/include/llvm/Support/ManagedStatic.h b/llvm/include/llvm/Support/ManagedStatic.h
+index f2b41422f13..01049e72beb 100644
+--- a/llvm/include/llvm/Support/ManagedStatic.h
++++ b/llvm/include/llvm/Support/ManagedStatic.h
+@@ -113,6 +113,14 @@ public:
+ /// llvm_shutdown - Deallocate and destroy all ManagedStatic variables.
+ void llvm_shutdown();
+ 
++/// Purpose of this function is to free memory allocated for ManagedStaticMutex.
++/// One might want to do that to avoid memory leaks in case LLVM is loaded as a
++/// shared library (or dll) at runtime.
++/// This function is not thread safe and should be called only if there are no
++/// threads which are using the mutex now or will use the mutex in the future.
++/// This means deleteManagedStaticMutex can be called only after llvm_shutdown.
++void deleteManagedStaticMutex();
++
+ /// llvm_shutdown_obj - This is a simple helper class that calls
+ /// llvm_shutdown() when it is destroyed.
+ struct llvm_shutdown_obj {
+diff --git a/llvm/lib/Support/ManagedStatic.cpp b/llvm/lib/Support/ManagedStatic.cpp
+index 053493f72fb..c843fabbe81 100644
+--- a/llvm/lib/Support/ManagedStatic.cpp
++++ b/llvm/lib/Support/ManagedStatic.cpp
+@@ -81,3 +81,8 @@ void llvm::llvm_shutdown() {
+   while (StaticList)
+     StaticList->destroy();
+ }
++
++void llvm::deleteManagedStaticMutex() {
++  assert(StaticList == nullptr && "llvm_shutdown() must be called first!");
++  delete ManagedStaticMutex;
++}
+\ No newline at end of file
+-- 
+2.18.1
+


### PR DESCRIPTION
Patch is downloaded from https://reviews.llvm.org/D52425
It can fix memory leak of ManagedStatic.