### PR TITLE
Apply llvm/clang patches together

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,20 +124,17 @@ if(NOT USE_PREBUILT_LLVM)
 
     set(SPIRV_BASE_REVISION llvm_release_110)
     set(TARGET_BRANCH "ocl-open-110")
-
-    apply_patches(${LLVM_SOURCE_DIR}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+    get_filename_component(LLVM_MONOREPO_DIR ${LLVM_SOURCE_DIR} DIRECTORY)
+    set(LLVM_PATCHES_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+                          ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang)
+    apply_patches(${LLVM_MONOREPO_DIR}
+                  "${LLVM_PATCHES_DIRS}"
                   ${LLVM_BASE_REVISION}
                   ${TARGET_BRANCH}
                   ret)
     if(${ret})
         add_definitions(-DAPPLIED_LLVM_PATCHES)
     endif()
-    apply_patches(${CLANG_SOURCE_DIR}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang
-                  ${CLANG_BASE_REVISION}
-                  ${TARGET_BRANCH}
-                  ret)
     apply_patches(${SPIRV_SOURCE_DIR}
                   ${CMAKE_CURRENT_SOURCE_DIR}/patches/spirv
                   ${SPIRV_BASE_REVISION}

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -44,8 +44,12 @@ endmacro(use_eh)
 # Then all patches from the `patches_dir` are committed to the `target_branch`.
 # Does nothing if the `target_branch` is already checked out in the `repo_dir`.
 #
-function(apply_patches repo_dir patches_dir base_revision target_branch ret)
-    file(GLOB patches ${patches_dir}/*.patch)
+function(apply_patches repo_dir patches_dirs base_revision target_branch ret)
+    set(patches "")
+    foreach(patches_dir ${patches_dirs})
+        file(GLOB patches_in_dir ${patches_dir}/*.patch)
+        list(APPEND patches ${patches_in_dir})
+    endforeach()
     if(NOT patches)
         message(STATUS "No patches in ${patches_dir}")
         return()


### PR DESCRIPTION
clang and llvm are in a monorepo since llvm 10, so we need to apply them
in a single apply_patches call. Otherwise patches in clang folder will
not be applied.
See https://github.com/intel/opencl-clang/pull/176#issuecomment-698040927