### PR TITLE
OpenCL C 3.0 patch update: define predefined macros in header if they…

### DIFF
--- a/patches/clang/0002-OpenCL-3.0-support.patch
+++ b/patches/clang/0002-OpenCL-3.0-support.patch
@@ -1,4 +1,4 @@
-From c1ea448c25d2ec358b8d26c51978c54eb99eb90c Mon Sep 17 00:00:00 2001
+From 9ea186c630ded3c903564480cd616dea63f38294 Mon Sep 17 00:00:00 2001
 From: Anton Zabaznov <anton.zabaznov@intel.com>
 Date: Thu, 24 Sep 2020 00:12:24 +0300
 Subject: [PATCH] OpenCL 3.0 support
@@ -21,7 +21,7 @@ Subject: [PATCH] OpenCL 3.0 support
  lib/CodeGen/CodeGenFunction.cpp               |    6 +-
  lib/Frontend/CompilerInvocation.cpp           |   22 +-
  lib/Frontend/InitPreprocessor.cpp             |    7 +-
- lib/Headers/opencl-c-base.h                   |   15 +-
+ lib/Headers/opencl-c-base.h                   |   78 +-
  lib/Headers/opencl-c.h                        | 3227 ++++++++++++++---
  lib/Parse/ParseDecl.cpp                       |   12 +-
  lib/Parse/ParsePragma.cpp                     |   10 +-
@@ -69,7 +69,7 @@ Subject: [PATCH] OpenCL 3.0 support
  .../SemaOpenCL/forget-unsupported-builtins.cl |   23 +
  test/SemaOpenCL/invalid-pipe-builtin-cl2.0.cl |    1 +
  test/SemaOpenCL/storageclass-cl20.cl          |    1 +
- 65 files changed, 3484 insertions(+), 690 deletions(-)
+ 65 files changed, 3547 insertions(+), 690 deletions(-)
  create mode 100644 test/CodeGenOpenCL/generic-address-space-feature.cl
  create mode 100644 test/Sema/feature-extensions-simult-support.cl
  create mode 100644 test/Sema/features-ignore-pragma.cl
@@ -794,19 +794,89 @@ index 6feb7bcbd4..57c810075e 100644
  #include "clang/Basic/OpenCLExtensions.def"
  
 diff --git a/lib/Headers/opencl-c-base.h b/lib/Headers/opencl-c-base.h
-index 9a23333a33..d81cbdb8a7 100644
+index 9a23333a33..40930adf23 100644
 --- a/lib/Headers/opencl-c-base.h
 +++ b/lib/Headers/opencl-c-base.h
-@@ -115,7 +115,7 @@ typedef half half4 __attribute__((ext_vector_type(4)));
+@@ -9,6 +9,64 @@
+ #ifndef _OPENCL_BASE_H_
+ #define _OPENCL_BASE_H_
+ 
++
++// Add predefined macros to build headers with standalone executable
++#ifndef CL_VERSION_3_0
++  #define CL_VERSION_3_0 300
++#endif
++#ifndef __OPENCL_MEMORY_SCOPE_ALL_DEVICES
++  #define __OPENCL_MEMORY_SCOPE_ALL_DEVICES 5
++#endif
++
++// Define features for 2.0 for header backward compatibility
++#ifndef __opencl_c_int64
++  #define __opencl_c_int64 1
++#endif
++#if __OPENCL_C_VERSION__ != CL_VERSION_3_0
++  #ifndef __opencl_c_images
++    #define __opencl_c_images 1
++  #endif
++#endif
++#if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ == CL_VERSION_2_0)
++#ifndef __opencl_c_pipes
++  #define __opencl_c_pipes 1
++#endif
++#ifndef __opencl_c_generic_address_space
++  #define __opencl_c_generic_address_space 1
++#endif
++#ifndef __opencl_c_work_group_collective_functions
++  #define __opencl_c_work_group_collective_functions 1
++#endif
++#ifndef __opencl_c_atomic_order_acq_rel
++  #define __opencl_c_atomic_order_acq_rel 1
++#endif
++#ifndef __opencl_c_atomic_order_seq_cst
++  #define __opencl_c_atomic_order_seq_cst 1
++#endif
++#ifndef __opencl_c_atomic_scope_device
++ #define __opencl_c_atomic_scope_device 1
++#endif
++#ifndef __opencl_c_atomic_scope_all_devices
++  #define __opencl_c_atomic_scope_all_devices 1
++#endif
++#ifndef __opencl_c_subgroups
++  #define __opencl_c_subgroups 1
++#endif
++#ifndef __opencl_c_3d_image_writes
++  #define __opencl_c_3d_image_writes 1
++#endif
++#ifndef __opencl_c_device_enqueue
++  #define __opencl_c_device_enqueue 1
++#endif
++#ifndef __opencl_c_read_write_images
++  #define __opencl_c_read_write_images 1
++#endif
++#ifndef __opencl_c_program_scope_global_variables
++  #define __opencl_c_program_scope_global_variables 1
++#endif
++#endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ == CL_VERSION_2_0)
++
++
+ // built-in scalar data types:
+ 
+ /**
+@@ -115,7 +173,12 @@ typedef half half4 __attribute__((ext_vector_type(4)));
  typedef half half8 __attribute__((ext_vector_type(8)));
  typedef half half16 __attribute__((ext_vector_type(16)));
  #endif
 -#ifdef cl_khr_fp64
 +#if defined(cl_khr_fp64) || defined(__opencl_c_fp64)
++
++#ifndef __opencl_c_fp64
++  #define __opencl_c_fp64 1
++#endif
++
  #if __OPENCL_C_VERSION__ < CL_VERSION_1_2
  #pragma OPENCL EXTENSION cl_khr_fp64 : enable
  #endif
-@@ -281,9 +281,15 @@ typedef uint cl_mem_fence_flags;
+@@ -281,9 +344,15 @@ typedef uint cl_mem_fence_flags;
  typedef enum memory_scope {
    memory_scope_work_item = __OPENCL_MEMORY_SCOPE_WORK_ITEM,
    memory_scope_work_group = __OPENCL_MEMORY_SCOPE_WORK_GROUP,
@@ -823,7 +893,7 @@ index 9a23333a33..d81cbdb8a7 100644
    memory_scope_sub_group = __OPENCL_MEMORY_SCOPE_SUB_GROUP
  #endif
  } memory_scope;
-@@ -301,13 +307,14 @@ typedef enum memory_scope {
+@@ -301,13 +370,14 @@ typedef enum memory_scope {
  #define ATOMIC_FLAG_INIT 0
  
  // enum values aligned with what clang uses in EmitAtomicExpr()


### PR DESCRIPTION
… are not defined by FE compiler