### PR TITLE
OpenCL C 3.0 patch update: memory_scope_all_devices is alias and available for 3.0 and newer

### DIFF
--- a/patches/clang/0002-OpenCL-3.0-support.patch
+++ b/patches/clang/0002-OpenCL-3.0-support.patch
@@ -1,4 +1,4 @@
-From 9ea186c630ded3c903564480cd616dea63f38294 Mon Sep 17 00:00:00 2001
+From 57879574d1521eebb715c810c1d4233afeee300c Mon Sep 17 00:00:00 2001
 From: Anton Zabaznov <anton.zabaznov@intel.com>
 Date: Thu, 24 Sep 2020 00:12:24 +0300
 Subject: [PATCH] OpenCL 3.0 support
@@ -20,8 +20,8 @@ Subject: [PATCH] OpenCL 3.0 support
  lib/Basic/Targets.cpp                         |    1 -
  lib/CodeGen/CodeGenFunction.cpp               |    6 +-
  lib/Frontend/CompilerInvocation.cpp           |   22 +-
- lib/Frontend/InitPreprocessor.cpp             |    7 +-
- lib/Headers/opencl-c-base.h                   |   78 +-
+ lib/Frontend/InitPreprocessor.cpp             |    6 +-
+ lib/Headers/opencl-c-base.h                   |   77 +-
  lib/Headers/opencl-c.h                        | 3227 ++++++++++++++---
  lib/Parse/ParseDecl.cpp                       |   12 +-
  lib/Parse/ParsePragma.cpp                     |   10 +-
@@ -56,7 +56,6 @@ Subject: [PATCH] OpenCL 3.0 support
  test/Frontend/stdlang.c                       |    1 +
  test/Headers/opencl-c-header.cl               |    7 +-
  test/Index/pipe-size.cl                       |    7 +
- test/Preprocessor/init.c                      |    1 +
  test/Preprocessor/predefined-macros.c         |   13 +
  .../Sema/feature-extensions-simult-support.cl |   75 +
  test/Sema/features-ignore-pragma.cl           |   24 +
@@ -69,7 +68,7 @@ Subject: [PATCH] OpenCL 3.0 support
  .../SemaOpenCL/forget-unsupported-builtins.cl |   23 +
  test/SemaOpenCL/invalid-pipe-builtin-cl2.0.cl |    1 +
  test/SemaOpenCL/storageclass-cl20.cl          |    1 +
- 65 files changed, 3547 insertions(+), 690 deletions(-)
+ 64 files changed, 3544 insertions(+), 690 deletions(-)
  create mode 100644 test/CodeGenOpenCL/generic-address-space-feature.cl
  create mode 100644 test/Sema/feature-extensions-simult-support.cl
  create mode 100644 test/Sema/features-ignore-pragma.cl
@@ -755,7 +754,7 @@ index bc54e38a1a..e9577d03c4 100644
    Opts.Coroutines = Opts.CPlusPlus2a || Args.hasArg(OPT_fcoroutines_ts);
  
 diff --git a/lib/Frontend/InitPreprocessor.cpp b/lib/Frontend/InitPreprocessor.cpp
-index 6feb7bcbd4..57c810075e 100644
+index 6feb7bcbd4..8264229dd6 100644
 --- a/lib/Frontend/InitPreprocessor.cpp
 +++ b/lib/Frontend/InitPreprocessor.cpp
 @@ -434,6 +434,9 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
@@ -776,15 +775,7 @@ index 6feb7bcbd4..57c810075e 100644
  
      if (TI.isLittleEndian())
        Builder.defineMacro("__ENDIAN_LITTLE__");
-@@ -600,6 +604,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
-   Builder.defineMacro("__OPENCL_MEMORY_SCOPE_DEVICE", "2");
-   Builder.defineMacro("__OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES", "3");
-   Builder.defineMacro("__OPENCL_MEMORY_SCOPE_SUB_GROUP", "4");
-+  Builder.defineMacro("__OPENCL_MEMORY_SCOPE_ALL_DEVICES", "5");
- 
-   // Support for #pragma redefine_extname (Sun compatibility)
-   Builder.defineMacro("__PRAGMA_REDEFINE_EXTNAME", "1");
-@@ -1067,7 +1072,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
+@@ -1067,7 +1071,7 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
    // OpenCL definitions.
    if (LangOpts.OpenCL) {
  #define OPENCLEXT(Ext)                                                         \
@@ -794,10 +785,10 @@ index 6feb7bcbd4..57c810075e 100644
  #include "clang/Basic/OpenCLExtensions.def"
  
 diff --git a/lib/Headers/opencl-c-base.h b/lib/Headers/opencl-c-base.h
-index 9a23333a33..40930adf23 100644
+index 9a23333a33..0b27e4010e 100644
 --- a/lib/Headers/opencl-c-base.h
 +++ b/lib/Headers/opencl-c-base.h
-@@ -9,6 +9,64 @@
+@@ -9,6 +9,61 @@
  #ifndef _OPENCL_BASE_H_
  #define _OPENCL_BASE_H_
  
@@ -805,9 +796,6 @@ index 9a23333a33..40930adf23 100644
 +// Add predefined macros to build headers with standalone executable
 +#ifndef CL_VERSION_3_0
 +  #define CL_VERSION_3_0 300
-+#endif
-+#ifndef __OPENCL_MEMORY_SCOPE_ALL_DEVICES
-+  #define __OPENCL_MEMORY_SCOPE_ALL_DEVICES 5
 +#endif
 +
 +// Define features for 2.0 for header backward compatibility
@@ -862,7 +850,7 @@ index 9a23333a33..40930adf23 100644
  // built-in scalar data types:
  
  /**
-@@ -115,7 +173,12 @@ typedef half half4 __attribute__((ext_vector_type(4)));
+@@ -115,7 +170,12 @@ typedef half half4 __attribute__((ext_vector_type(4)));
  typedef half half8 __attribute__((ext_vector_type(8)));
  typedef half half16 __attribute__((ext_vector_type(16)));
  #endif
@@ -876,7 +864,7 @@ index 9a23333a33..40930adf23 100644
  #if __OPENCL_C_VERSION__ < CL_VERSION_1_2
  #pragma OPENCL EXTENSION cl_khr_fp64 : enable
  #endif
-@@ -281,9 +344,15 @@ typedef uint cl_mem_fence_flags;
+@@ -281,9 +341,17 @@ typedef uint cl_mem_fence_flags;
  typedef enum memory_scope {
    memory_scope_work_item = __OPENCL_MEMORY_SCOPE_WORK_ITEM,
    memory_scope_work_group = __OPENCL_MEMORY_SCOPE_WORK_GROUP,
@@ -884,16 +872,18 @@ index 9a23333a33..40930adf23 100644
    memory_scope_device = __OPENCL_MEMORY_SCOPE_DEVICE,
 +#endif
 +#ifdef __opencl_c_atomic_scope_all_devices
-+  memory_scope_all_devices = __OPENCL_MEMORY_SCOPE_ALL_DEVICES,
++  #if (__OPENCL_C_VERSION__ >= CL_VERSION_3_0)
++  memory_scope_all_devices = __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES,
++  #endif // (__OPENCL_C_VERSION__ >= CL_VERSION_3_0)
    memory_scope_all_svm_devices = __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES,
 -#if defined(cl_intel_subgroups) || defined(cl_khr_subgroups)
-+#endif
++#endif // __opencl_c_atomic_scope_all_devices
 +#if defined(cl_intel_subgroups) || defined(cl_khr_subgroups) ||                \
 +    defined(__opencl_c_subgroups)
    memory_scope_sub_group = __OPENCL_MEMORY_SCOPE_SUB_GROUP
  #endif
  } memory_scope;
-@@ -301,13 +370,14 @@ typedef enum memory_scope {
+@@ -301,13 +369,14 @@ typedef enum memory_scope {
  #define ATOMIC_FLAG_INIT 0
  
  // enum values aligned with what clang uses in EmitAtomicExpr()
@@ -7450,18 +7440,6 @@ index 94a1255f0a..59b76051ed 100644
  __kernel void testPipe( pipe int test )
  {
      int s = sizeof(test);
-diff --git a/test/Preprocessor/init.c b/test/Preprocessor/init.c
-index 954f02a014..85b1376eca 100644
---- a/test/Preprocessor/init.c
-+++ b/test/Preprocessor/init.c
-@@ -9888,6 +9888,7 @@
- // WEBASSEMBLY64-NEXT:#define __LP64__ 1
- // WEBASSEMBLY-NEXT:#define __NO_INLINE__ 1
- // WEBASSEMBLY-NEXT:#define __OBJC_BOOL_IS_BOOL 0
-+// WEBASSEMBLY-NEXT:#define __OPENCL_MEMORY_SCOPE_ALL_DEVICES 5
- // WEBASSEMBLY-NEXT:#define __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES 3
- // WEBASSEMBLY-NEXT:#define __OPENCL_MEMORY_SCOPE_DEVICE 2
- // WEBASSEMBLY-NEXT:#define __OPENCL_MEMORY_SCOPE_SUB_GROUP 4
 diff --git a/test/Preprocessor/predefined-macros.c b/test/Preprocessor/predefined-macros.c
 index def105f4c5..b088a37ba6 100644
 --- a/test/Preprocessor/predefined-macros.c

--- a/patches/clang/0002-OpenCL-3.0-support.patch
+++ b/patches/clang/0002-OpenCL-3.0-support.patch
@@ -1,4 +1,4 @@
-From 57879574d1521eebb715c810c1d4233afeee300c Mon Sep 17 00:00:00 2001
+From 783f9e3f6add102feece1e7632e97cf4e9df11a9 Mon Sep 17 00:00:00 2001
 From: Anton Zabaznov <anton.zabaznov@intel.com>
 Date: Thu, 24 Sep 2020 00:12:24 +0300
 Subject: [PATCH] OpenCL 3.0 support
@@ -22,7 +22,7 @@ Subject: [PATCH] OpenCL 3.0 support
  lib/Frontend/CompilerInvocation.cpp           |   22 +-
  lib/Frontend/InitPreprocessor.cpp             |    6 +-
  lib/Headers/opencl-c-base.h                   |   77 +-
- lib/Headers/opencl-c.h                        | 3227 ++++++++++++++---
+ lib/Headers/opencl-c.h                        | 3228 ++++++++++++++---
  lib/Parse/ParseDecl.cpp                       |   12 +-
  lib/Parse/ParsePragma.cpp                     |   10 +-
  lib/Sema/Sema.cpp                             |   47 +-
@@ -68,7 +68,7 @@ Subject: [PATCH] OpenCL 3.0 support
  .../SemaOpenCL/forget-unsupported-builtins.cl |   23 +
  test/SemaOpenCL/invalid-pipe-builtin-cl2.0.cl |    1 +
  test/SemaOpenCL/storageclass-cl20.cl          |    1 +
- 64 files changed, 3544 insertions(+), 690 deletions(-)
+ 64 files changed, 3546 insertions(+), 689 deletions(-)
  create mode 100644 test/CodeGenOpenCL/generic-address-space-feature.cl
  create mode 100644 test/Sema/feature-extensions-simult-support.cl
  create mode 100644 test/Sema/features-ignore-pragma.cl
@@ -901,7 +901,7 @@ index 9a23333a33..0b27e4010e 100644
  
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
 diff --git a/lib/Headers/opencl-c.h b/lib/Headers/opencl-c.h
-index d3ae0dd503..2782e5bf5d 100644
+index d3ae0dd503..d63731166d 100644
 --- a/lib/Headers/opencl-c.h
 +++ b/lib/Headers/opencl-c.h
 @@ -35,7 +35,6 @@
@@ -3597,7 +3597,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
  
  // OpenCL v2.0 s6.13.11.7.5:
-@@ -13501,196 +13483,2236 @@ ulong __ovld atomic_fetch_max_explicit(volatile atomic_ulong *object, long opera
+@@ -13501,196 +13483,2239 @@ ulong __ovld atomic_fetch_max_explicit(volatile atomic_ulong *object, long opera
  // or/xor/and/min/max: atomic type argument can be intptr_t/uintptr_t, value type argument can be intptr_t/uintptr_t.
  
  #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
@@ -4532,10 +4532,10 @@ index d3ae0dd503..2782e5bf5d 100644
 -void __ovld atomic_store_explicit(volatile atomic_double *object, double desired, memory_order order);
 -void __ovld atomic_store_explicit(volatile atomic_double *object, double desired, memory_order order, memory_scope scope);
 -#endif //cl_khr_fp64
--void __ovld atomic_store(volatile atomic_long *object, long desired);
++#endif
+ void __ovld atomic_store(volatile atomic_long *object, long desired);
 -void __ovld atomic_store_explicit(volatile atomic_long *object, long desired, memory_order order);
 -void __ovld atomic_store_explicit(volatile atomic_long *object, long desired, memory_order order, memory_scope scope);
-+#endif
  void __ovld atomic_store(volatile atomic_ulong *object, ulong desired);
 -void __ovld atomic_store_explicit(volatile atomic_ulong *object, ulong desired, memory_order order);
 -void __ovld atomic_store_explicit(volatile atomic_ulong *object, ulong desired, memory_order order, memory_scope scope);
@@ -4557,6 +4557,8 @@ index d3ae0dd503..2782e5bf5d 100644
 +void __ovld atomic_store(volatile atomic_double __local *object,
 +                         double desired);
  #endif
++void __ovld atomic_store(volatile atomic_long __global *object, long desired);
++void __ovld atomic_store(volatile atomic_long __local *object, long desired);
 +void __ovld atomic_store(volatile atomic_ulong __global *object, ulong desired);
 +void __ovld atomic_store(volatile atomic_ulong __local *object, ulong desired);
 +#endif // defined(cl_khr_int64_base_atomics) &&
@@ -5986,7 +5988,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
-@@ -13918,7 +15940,7 @@ float16 __ovld __cnfn shuffle(float4 x, uint16 mask);
+@@ -13918,7 +15943,7 @@ float16 __ovld __cnfn shuffle(float4 x, uint16 mask);
  float16 __ovld __cnfn shuffle(float8 x, uint16 mask);
  float16 __ovld __cnfn shuffle(float16 x, uint16 mask);
  
@@ -5995,7 +5997,7 @@ index d3ae0dd503..2782e5bf5d 100644
  double2 __ovld __cnfn shuffle(double2 x, ulong2 mask);
  double2 __ovld __cnfn shuffle(double4 x, ulong2 mask);
  double2 __ovld __cnfn shuffle(double8 x, ulong2 mask);
-@@ -13938,7 +15960,7 @@ double16 __ovld __cnfn shuffle(double2 x, ulong16 mask);
+@@ -13938,7 +15963,7 @@ double16 __ovld __cnfn shuffle(double2 x, ulong16 mask);
  double16 __ovld __cnfn shuffle(double4 x, ulong16 mask);
  double16 __ovld __cnfn shuffle(double8 x, ulong16 mask);
  double16 __ovld __cnfn shuffle(double16 x, ulong16 mask);
@@ -6004,7 +6006,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  #ifdef cl_khr_fp16
  half2 __ovld __cnfn shuffle(half2 x, ushort2 mask);
-@@ -14142,7 +16164,7 @@ float16 __ovld __cnfn shuffle2(float4 x, float4 y, uint16 mask);
+@@ -14142,7 +16167,7 @@ float16 __ovld __cnfn shuffle2(float4 x, float4 y, uint16 mask);
  float16 __ovld __cnfn shuffle2(float8 x, float8 y, uint16 mask);
  float16 __ovld __cnfn shuffle2(float16 x, float16 y, uint16 mask);
  
@@ -6013,7 +6015,7 @@ index d3ae0dd503..2782e5bf5d 100644
  double2 __ovld __cnfn shuffle2(double2 x, double2 y, ulong2 mask);
  double2 __ovld __cnfn shuffle2(double4 x, double4 y, ulong2 mask);
  double2 __ovld __cnfn shuffle2(double8 x, double8 y, ulong2 mask);
-@@ -14162,7 +16184,7 @@ double16 __ovld __cnfn shuffle2(double2 x, double2 y, ulong16 mask);
+@@ -14162,7 +16187,7 @@ double16 __ovld __cnfn shuffle2(double2 x, double2 y, ulong16 mask);
  double16 __ovld __cnfn shuffle2(double4 x, double4 y, ulong16 mask);
  double16 __ovld __cnfn shuffle2(double8 x, double8 y, ulong16 mask);
  double16 __ovld __cnfn shuffle2(double16 x, double16 y, ulong16 mask);
@@ -6022,7 +6024,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  #ifdef cl_khr_fp16
  half2 __ovld __cnfn shuffle2(half2 x, half2 y, ushort2 mask);
-@@ -14198,6 +16220,7 @@ int printf(__constant const char* st, ...) __attribute__((format(printf, 1, 2)))
+@@ -14198,6 +16223,7 @@ int printf(__constant const char* st, ...) __attribute__((format(printf, 1, 2)))
  #pragma OPENCL EXTENSION cl_khr_gl_msaa_sharing : enable
  #endif //cl_khr_gl_msaa_sharing
  
@@ -6030,7 +6032,7 @@ index d3ae0dd503..2782e5bf5d 100644
  /**
   * Use the coordinate (coord.xy) to do an element lookup in
   * the 2D image object specified by image.
-@@ -14476,6 +16499,7 @@ half4 __purefn __ovld read_imageh(read_only image1d_buffer_t image, int coord);
+@@ -14476,6 +16502,7 @@ half4 __purefn __ovld read_imageh(read_only image1d_buffer_t image, int coord);
  
  // Image read functions for read_write images
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6038,7 +6040,7 @@ index d3ae0dd503..2782e5bf5d 100644
  float4 __purefn __ovld read_imagef(read_write image1d_t image, int coord);
  int4 __purefn __ovld read_imagei(read_write image1d_t image, int coord);
  uint4 __purefn __ovld read_imageui(read_write image1d_t image, int coord);
-@@ -14519,6 +16543,7 @@ float __purefn __ovld read_imagef(read_write image2d_array_msaa_depth_t image, i
+@@ -14519,6 +16546,7 @@ float __purefn __ovld read_imagef(read_write image2d_array_msaa_depth_t image, i
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6046,7 +6048,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #ifdef cl_khr_mipmap_image
  float4 __purefn __ovld read_imagef(read_write image1d_t image, sampler_t sampler, float coord, float lod);
  int4 __purefn __ovld read_imagei(read_write image1d_t image, sampler_t sampler, float coord, float lod);
-@@ -14569,6 +16594,7 @@ int4 __purefn __ovld read_imagei(read_write image3d_t image, sampler_t sampler,
+@@ -14569,6 +16597,7 @@ int4 __purefn __ovld read_imagei(read_write image3d_t image, sampler_t sampler,
  uint4 __purefn __ovld read_imageui(read_write image3d_t image, sampler_t sampler, float4 coord, float4 gradientX, float4 gradientY);
  
  #endif //cl_khr_mipmap_image
@@ -6054,7 +6056,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  // Image read functions returning half4 type
-@@ -14580,6 +16606,7 @@ half4 __purefn __ovld read_imageh(read_write image1d_array_t image, int2 coord);
+@@ -14580,6 +16609,7 @@ half4 __purefn __ovld read_imageh(read_write image1d_array_t image, int2 coord);
  half4 __purefn __ovld read_imageh(read_write image2d_array_t image, int4 coord);
  half4 __purefn __ovld read_imageh(read_write image1d_buffer_t image, int coord);
  #endif //cl_khr_fp16
@@ -6062,7 +6064,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -14669,7 +16696,7 @@ void __ovld write_imagef(write_only image1d_array_t image_array, int2 coord, flo
+@@ -14669,7 +16699,7 @@ void __ovld write_imagef(write_only image1d_array_t image_array, int2 coord, flo
  void __ovld write_imagei(write_only image1d_array_t image_array, int2 coord, int4 color);
  void __ovld write_imageui(write_only image1d_array_t image_array, int2 coord, uint4 color);
  
@@ -6071,7 +6073,7 @@ index d3ae0dd503..2782e5bf5d 100644
  void __ovld write_imagef(write_only image3d_t image, int4 coord, float4 color);
  void __ovld write_imagei(write_only image3d_t image, int4 coord, int4 color);
  void __ovld write_imageui(write_only image3d_t image, int4 coord, uint4 color);
-@@ -14703,7 +16730,7 @@ void __ovld write_imageui(write_only image2d_array_t image_array, int4 coord, in
+@@ -14703,7 +16733,7 @@ void __ovld write_imageui(write_only image2d_array_t image_array, int4 coord, in
  void __ovld write_imagef(write_only image2d_depth_t image, int2 coord, int lod, float depth);
  void __ovld write_imagef(write_only image2d_array_depth_t image, int4 coord, int lod, float depth);
  
@@ -6080,7 +6082,7 @@ index d3ae0dd503..2782e5bf5d 100644
  void __ovld write_imagef(write_only image3d_t image, int4 coord, int lod, float4 color);
  void __ovld write_imagei(write_only image3d_t image, int4 coord, int lod, int4 color);
  void __ovld write_imageui(write_only image3d_t image, int4 coord, int lod, uint4 color);
-@@ -14717,7 +16744,7 @@ void __ovld write_imageui(write_only image3d_t image, int4 coord, int lod, uint4
+@@ -14717,7 +16747,7 @@ void __ovld write_imageui(write_only image3d_t image, int4 coord, int lod, uint4
  #ifdef cl_khr_fp16
  void __ovld write_imageh(write_only image1d_t image, int coord, half4 color);
  void __ovld write_imageh(write_only image2d_t image, int2 coord, half4 color);
@@ -6089,7 +6091,7 @@ index d3ae0dd503..2782e5bf5d 100644
  void __ovld write_imageh(write_only image3d_t image, int4 coord, half4 color);
  #endif
  void __ovld write_imageh(write_only image1d_array_t image, int2 coord, half4 color);
-@@ -14727,6 +16754,7 @@ void __ovld write_imageh(write_only image1d_buffer_t image, int coord, half4 col
+@@ -14727,6 +16757,7 @@ void __ovld write_imageh(write_only image1d_buffer_t image, int coord, half4 col
  
  // Image write functions for read_write images
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6097,7 +6099,7 @@ index d3ae0dd503..2782e5bf5d 100644
  void __ovld write_imagef(read_write image2d_t image, int2 coord, float4 color);
  void __ovld write_imagei(read_write image2d_t image, int2 coord, int4 color);
  void __ovld write_imageui(read_write image2d_t image, int2 coord, uint4 color);
-@@ -14747,7 +16775,7 @@ void __ovld write_imagef(read_write image1d_array_t image_array, int2 coord, flo
+@@ -14747,7 +16778,7 @@ void __ovld write_imagef(read_write image1d_array_t image_array, int2 coord, flo
  void __ovld write_imagei(read_write image1d_array_t image_array, int2 coord, int4 color);
  void __ovld write_imageui(read_write image1d_array_t image_array, int2 coord, uint4 color);
  
@@ -6106,7 +6108,7 @@ index d3ae0dd503..2782e5bf5d 100644
  void __ovld write_imagef(read_write image3d_t image, int4 coord, float4 color);
  void __ovld write_imagei(read_write image3d_t image, int4 coord, int4 color);
  void __ovld write_imageui(read_write image3d_t image, int4 coord, uint4 color);
-@@ -14780,7 +16808,7 @@ void __ovld write_imageui(read_write image2d_array_t image_array, int4 coord, in
+@@ -14780,7 +16811,7 @@ void __ovld write_imageui(read_write image2d_array_t image_array, int4 coord, in
  void __ovld write_imagef(read_write image2d_depth_t image, int2 coord, int lod, float color);
  void __ovld write_imagef(read_write image2d_array_depth_t image, int4 coord, int lod, float color);
  
@@ -6115,7 +6117,7 @@ index d3ae0dd503..2782e5bf5d 100644
  void __ovld write_imagef(read_write image3d_t image, int4 coord, int lod, float4 color);
  void __ovld write_imagei(read_write image3d_t image, int4 coord, int lod, int4 color);
  void __ovld write_imageui(read_write image3d_t image, int4 coord, int lod, uint4 color);
-@@ -14794,13 +16822,14 @@ void __ovld write_imageui(read_write image3d_t image, int4 coord, int lod, uint4
+@@ -14794,13 +16825,14 @@ void __ovld write_imageui(read_write image3d_t image, int4 coord, int lod, uint4
  #ifdef cl_khr_fp16
  void __ovld write_imageh(read_write image1d_t image, int coord, half4 color);
  void __ovld write_imageh(read_write image2d_t image, int2 coord, half4 color);
@@ -6131,7 +6133,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  // Note: In OpenCL v1.0/1.1/1.2, image argument of image query builtin functions does not have
-@@ -14814,7 +16843,7 @@ void __ovld write_imageh(read_write image1d_buffer_t image, int coord, half4 col
+@@ -14814,7 +16846,7 @@ void __ovld write_imageh(read_write image1d_buffer_t image, int coord, half4 col
  int __ovld __cnfn get_image_width(read_only image1d_t image);
  int __ovld __cnfn get_image_width(read_only image1d_buffer_t image);
  int __ovld __cnfn get_image_width(read_only image2d_t image);
@@ -6140,7 +6142,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_width(read_only image3d_t image);
  #endif
  int __ovld __cnfn get_image_width(read_only image1d_array_t image);
-@@ -14833,7 +16862,7 @@ int __ovld __cnfn get_image_width(read_only image2d_array_msaa_depth_t image);
+@@ -14833,7 +16865,7 @@ int __ovld __cnfn get_image_width(read_only image2d_array_msaa_depth_t image);
  int __ovld __cnfn get_image_width(write_only image1d_t image);
  int __ovld __cnfn get_image_width(write_only image1d_buffer_t image);
  int __ovld __cnfn get_image_width(write_only image2d_t image);
@@ -6149,7 +6151,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_width(write_only image3d_t image);
  #endif
  int __ovld __cnfn get_image_width(write_only image1d_array_t image);
-@@ -14850,6 +16879,7 @@ int __ovld __cnfn get_image_width(write_only image2d_array_msaa_depth_t image);
+@@ -14850,6 +16882,7 @@ int __ovld __cnfn get_image_width(write_only image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6157,7 +6159,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_width(read_write image1d_t image);
  int __ovld __cnfn get_image_width(read_write image1d_buffer_t image);
  int __ovld __cnfn get_image_width(read_write image2d_t image);
-@@ -14866,6 +16896,7 @@ int __ovld __cnfn get_image_width(read_write image2d_msaa_depth_t image);
+@@ -14866,6 +16899,7 @@ int __ovld __cnfn get_image_width(read_write image2d_msaa_depth_t image);
  int __ovld __cnfn get_image_width(read_write image2d_array_msaa_t image);
  int __ovld __cnfn get_image_width(read_write image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
@@ -6165,7 +6167,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -14886,7 +16917,7 @@ int __ovld __cnfn get_image_height(read_only image2d_array_msaa_depth_t image);
+@@ -14886,7 +16920,7 @@ int __ovld __cnfn get_image_height(read_only image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
  
  int __ovld __cnfn get_image_height(write_only image2d_t image);
@@ -6174,7 +6176,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_height(write_only image3d_t image);
  #endif
  int __ovld __cnfn get_image_height(write_only image2d_array_t image);
-@@ -14902,6 +16933,7 @@ int __ovld __cnfn get_image_height(write_only image2d_array_msaa_depth_t image);
+@@ -14902,6 +16936,7 @@ int __ovld __cnfn get_image_height(write_only image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6182,7 +6184,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_height(read_write image2d_t image);
  int __ovld __cnfn get_image_height(read_write image3d_t image);
  int __ovld __cnfn get_image_height(read_write image2d_array_t image);
-@@ -14915,6 +16947,7 @@ int __ovld __cnfn get_image_height(read_write image2d_msaa_depth_t image);
+@@ -14915,6 +16950,7 @@ int __ovld __cnfn get_image_height(read_write image2d_msaa_depth_t image);
  int __ovld __cnfn get_image_height(read_write image2d_array_msaa_t image);
  int __ovld __cnfn get_image_height(read_write image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
@@ -6190,7 +6192,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -14922,12 +16955,14 @@ int __ovld __cnfn get_image_height(read_write image2d_array_msaa_depth_t image);
+@@ -14922,12 +16958,14 @@ int __ovld __cnfn get_image_height(read_write image2d_array_msaa_depth_t image);
   */
  int __ovld __cnfn get_image_depth(read_only image3d_t image);
  
@@ -6206,7 +6208,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  // OpenCL Extension v2.0 s9.18 - Mipmaps
-@@ -14943,13 +16978,15 @@ int __ovld get_image_num_mip_levels(read_only image3d_t image);
+@@ -14943,13 +16981,15 @@ int __ovld get_image_num_mip_levels(read_only image3d_t image);
  
  int __ovld get_image_num_mip_levels(write_only image1d_t image);
  int __ovld get_image_num_mip_levels(write_only image2d_t image);
@@ -6223,7 +6225,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  int __ovld get_image_num_mip_levels(read_only image1d_array_t image);
  int __ovld get_image_num_mip_levels(read_only image2d_array_t image);
-@@ -14961,10 +16998,12 @@ int __ovld get_image_num_mip_levels(write_only image2d_array_t image);
+@@ -14961,10 +17001,12 @@ int __ovld get_image_num_mip_levels(write_only image2d_array_t image);
  int __ovld get_image_num_mip_levels(write_only image2d_array_depth_t image);
  int __ovld get_image_num_mip_levels(write_only image2d_depth_t image);
  
@@ -6236,7 +6238,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  #endif //cl_khr_mipmap_image
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
-@@ -15008,7 +17047,7 @@ int __ovld __cnfn get_image_channel_data_type(read_only image2d_array_msaa_depth
+@@ -15008,7 +17050,7 @@ int __ovld __cnfn get_image_channel_data_type(read_only image2d_array_msaa_depth
  int __ovld __cnfn get_image_channel_data_type(write_only image1d_t image);
  int __ovld __cnfn get_image_channel_data_type(write_only image1d_buffer_t image);
  int __ovld __cnfn get_image_channel_data_type(write_only image2d_t image);
@@ -6245,7 +6247,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_channel_data_type(write_only image3d_t image);
  #endif
  int __ovld __cnfn get_image_channel_data_type(write_only image1d_array_t image);
-@@ -15025,6 +17064,7 @@ int __ovld __cnfn get_image_channel_data_type(write_only image2d_array_msaa_dept
+@@ -15025,6 +17067,7 @@ int __ovld __cnfn get_image_channel_data_type(write_only image2d_array_msaa_dept
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6253,7 +6255,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_channel_data_type(read_write image1d_t image);
  int __ovld __cnfn get_image_channel_data_type(read_write image1d_buffer_t image);
  int __ovld __cnfn get_image_channel_data_type(read_write image2d_t image);
-@@ -15041,6 +17081,7 @@ int __ovld __cnfn get_image_channel_data_type(read_write image2d_msaa_depth_t im
+@@ -15041,6 +17084,7 @@ int __ovld __cnfn get_image_channel_data_type(read_write image2d_msaa_depth_t im
  int __ovld __cnfn get_image_channel_data_type(read_write image2d_array_msaa_t image);
  int __ovld __cnfn get_image_channel_data_type(read_write image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
@@ -6261,7 +6263,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -15080,7 +17121,7 @@ int __ovld __cnfn get_image_channel_order(read_only image2d_array_msaa_depth_t i
+@@ -15080,7 +17124,7 @@ int __ovld __cnfn get_image_channel_order(read_only image2d_array_msaa_depth_t i
  int __ovld __cnfn get_image_channel_order(write_only image1d_t image);
  int __ovld __cnfn get_image_channel_order(write_only image1d_buffer_t image);
  int __ovld __cnfn get_image_channel_order(write_only image2d_t image);
@@ -6270,7 +6272,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_channel_order(write_only image3d_t image);
  #endif
  int __ovld __cnfn get_image_channel_order(write_only image1d_array_t image);
-@@ -15097,6 +17138,7 @@ int __ovld __cnfn get_image_channel_order(write_only image2d_array_msaa_depth_t
+@@ -15097,6 +17141,7 @@ int __ovld __cnfn get_image_channel_order(write_only image2d_array_msaa_depth_t
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6278,7 +6280,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __cnfn get_image_channel_order(read_write image1d_t image);
  int __ovld __cnfn get_image_channel_order(read_write image1d_buffer_t image);
  int __ovld __cnfn get_image_channel_order(read_write image2d_t image);
-@@ -15113,6 +17155,7 @@ int __ovld __cnfn get_image_channel_order(read_write image2d_msaa_depth_t image)
+@@ -15113,6 +17158,7 @@ int __ovld __cnfn get_image_channel_order(read_write image2d_msaa_depth_t image)
  int __ovld __cnfn get_image_channel_order(read_write image2d_array_msaa_t image);
  int __ovld __cnfn get_image_channel_order(read_write image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
@@ -6286,7 +6288,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -15147,6 +17190,7 @@ int2 __ovld __cnfn get_image_dim(write_only image2d_array_msaa_depth_t image);
+@@ -15147,6 +17193,7 @@ int2 __ovld __cnfn get_image_dim(write_only image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6294,7 +6296,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int2 __ovld __cnfn get_image_dim(read_write image2d_t image);
  int2 __ovld __cnfn get_image_dim(read_write image2d_array_t image);
  #ifdef cl_khr_depth_images
-@@ -15159,6 +17203,7 @@ int2 __ovld __cnfn get_image_dim(read_write image2d_msaa_depth_t image);
+@@ -15159,6 +17206,7 @@ int2 __ovld __cnfn get_image_dim(read_write image2d_msaa_depth_t image);
  int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_t image);
  int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_depth_t image);
  #endif //cl_khr_gl_msaa_sharing
@@ -6302,7 +6304,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -15168,11 +17213,13 @@ int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_depth_t image);
+@@ -15168,11 +17216,13 @@ int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_depth_t image);
   * component and the w component is 0.
   */
  int4 __ovld __cnfn get_image_dim(read_only image3d_t image);
@@ -6317,7 +6319,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -15200,6 +17247,7 @@ size_t __ovld __cnfn get_image_array_size(write_only image2d_array_msaa_depth_t
+@@ -15200,6 +17250,7 @@ size_t __ovld __cnfn get_image_array_size(write_only image2d_array_msaa_depth_t
  #endif //cl_khr_gl_msaa_sharing
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6325,7 +6327,7 @@ index d3ae0dd503..2782e5bf5d 100644
  size_t __ovld __cnfn get_image_array_size(read_write image1d_array_t image_array);
  size_t __ovld __cnfn get_image_array_size(read_write image2d_array_t image_array);
  #ifdef cl_khr_depth_images
-@@ -15209,6 +17257,7 @@ size_t __ovld __cnfn get_image_array_size(read_write image2d_array_depth_t image
+@@ -15209,6 +17260,7 @@ size_t __ovld __cnfn get_image_array_size(read_write image2d_array_depth_t image
  size_t __ovld __cnfn get_image_array_size(read_write image2d_array_msaa_t image_array);
  size_t __ovld __cnfn get_image_array_size(read_write image2d_array_msaa_depth_t image_array);
  #endif //cl_khr_gl_msaa_sharing
@@ -6333,7 +6335,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  /**
-@@ -15226,16 +17275,21 @@ int __ovld get_image_num_samples(write_only image2d_array_msaa_t image);
+@@ -15226,16 +17278,21 @@ int __ovld get_image_num_samples(write_only image2d_array_msaa_t image);
  int __ovld get_image_num_samples(write_only image2d_array_msaa_depth_t image);
  
  #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
@@ -6355,7 +6357,7 @@ index d3ae0dd503..2782e5bf5d 100644
  int __ovld __conv work_group_all(int predicate);
  int __ovld __conv work_group_any(int predicate);
  
-@@ -15259,11 +17313,11 @@ ulong __ovld __conv work_group_broadcast(ulong a, size_t x, size_t y, size_t z);
+@@ -15259,11 +17316,11 @@ ulong __ovld __conv work_group_broadcast(ulong a, size_t x, size_t y, size_t z);
  float __ovld __conv work_group_broadcast(float a, size_t local_id);
  float __ovld __conv work_group_broadcast(float a, size_t x, size_t y);
  float __ovld __conv work_group_broadcast(float a, size_t x, size_t y, size_t z);
@@ -6369,7 +6371,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  #ifdef cl_khr_fp16
  half __ovld __conv work_group_reduce_add(half x);
-@@ -15321,7 +17375,7 @@ float __ovld __conv work_group_scan_exclusive_max(float x);
+@@ -15321,7 +17378,7 @@ float __ovld __conv work_group_scan_exclusive_max(float x);
  float __ovld __conv work_group_scan_inclusive_add(float x);
  float __ovld __conv work_group_scan_inclusive_min(float x);
  float __ovld __conv work_group_scan_inclusive_max(float x);
@@ -6378,7 +6380,7 @@ index d3ae0dd503..2782e5bf5d 100644
  double __ovld __conv work_group_reduce_add(double x);
  double __ovld __conv work_group_reduce_min(double x);
  double __ovld __conv work_group_reduce_max(double x);
-@@ -15331,19 +17385,18 @@ double __ovld __conv work_group_scan_exclusive_max(double x);
+@@ -15331,19 +17388,18 @@ double __ovld __conv work_group_scan_exclusive_max(double x);
  double __ovld __conv work_group_scan_inclusive_add(double x);
  double __ovld __conv work_group_scan_inclusive_min(double x);
  double __ovld __conv work_group_scan_inclusive_max(double x);
@@ -6403,7 +6405,7 @@ index d3ae0dd503..2782e5bf5d 100644
  ndrange_t __ovld ndrange_1D(size_t);
  ndrange_t __ovld ndrange_1D(size_t, size_t);
  ndrange_t __ovld ndrange_1D(size_t, size_t, size_t);
-@@ -15371,11 +17424,13 @@ bool __ovld is_valid_event (clk_event_t event);
+@@ -15371,11 +17427,13 @@ bool __ovld is_valid_event (clk_event_t event);
  void __ovld capture_event_profiling_info(clk_event_t, clk_profiling_info, __global void* value);
  
  queue_t __ovld get_default_queue(void);
@@ -6418,7 +6420,7 @@ index d3ae0dd503..2782e5bf5d 100644
  // Shared Sub Group Functions
  uint    __ovld get_sub_group_size(void);
  uint    __ovld get_max_sub_group_size(void);
-@@ -15461,7 +17516,7 @@ half    __ovld __conv sub_group_scan_inclusive_min(half x);
+@@ -15461,7 +17519,7 @@ half    __ovld __conv sub_group_scan_inclusive_min(half x);
  half    __ovld __conv sub_group_scan_inclusive_max(half x);
  #endif //cl_khr_fp16
  
@@ -6427,7 +6429,7 @@ index d3ae0dd503..2782e5bf5d 100644
  double  __ovld __conv sub_group_broadcast(double x, uint sub_group_local_id);
  double  __ovld __conv sub_group_reduce_add(double x);
  double  __ovld __conv sub_group_reduce_min(double x);
-@@ -15472,7 +17527,7 @@ double  __ovld __conv sub_group_scan_exclusive_max(double x);
+@@ -15472,7 +17530,7 @@ double  __ovld __conv sub_group_scan_exclusive_max(double x);
  double  __ovld __conv sub_group_scan_inclusive_add(double x);
  double  __ovld __conv sub_group_scan_inclusive_min(double x);
  double  __ovld __conv sub_group_scan_inclusive_max(double x);
@@ -6436,7 +6438,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  #endif //cl_khr_subgroups cl_intel_subgroups
  
-@@ -15574,16 +17629,22 @@ uint16  __ovld __conv intel_sub_group_shuffle_xor( uint16 x, uint c );
+@@ -15574,16 +17632,22 @@ uint16  __ovld __conv intel_sub_group_shuffle_xor( uint16 x, uint c );
  long    __ovld __conv intel_sub_group_shuffle_xor( long x, uint c );
  ulong   __ovld __conv intel_sub_group_shuffle_xor( ulong x, uint c );
  
@@ -6459,7 +6461,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  uint    __ovld __conv intel_sub_group_block_read( const __global uint* p );
-@@ -15591,16 +17652,22 @@ uint2   __ovld __conv intel_sub_group_block_read2( const __global uint* p );
+@@ -15591,16 +17655,22 @@ uint2   __ovld __conv intel_sub_group_block_read2( const __global uint* p );
  uint4   __ovld __conv intel_sub_group_block_read4( const __global uint* p );
  uint8   __ovld __conv intel_sub_group_block_read8( const __global uint* p );
  
@@ -6482,7 +6484,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  void    __ovld __conv intel_sub_group_block_write( __global uint* p, uint data );
-@@ -15615,7 +17682,7 @@ half    __ovld __conv intel_sub_group_shuffle_up( half prev, half cur, uint c );
+@@ -15615,7 +17685,7 @@ half    __ovld __conv intel_sub_group_shuffle_up( half prev, half cur, uint c );
  half    __ovld __conv intel_sub_group_shuffle_xor( half x, uint c );
  #endif
  
@@ -6491,7 +6493,7 @@ index d3ae0dd503..2782e5bf5d 100644
  double  __ovld __conv intel_sub_group_shuffle( double x, uint c );
  double  __ovld __conv intel_sub_group_shuffle_down( double prev, double cur, uint c );
  double  __ovld __conv intel_sub_group_shuffle_up( double prev, double cur, uint c );
-@@ -15714,16 +17781,22 @@ ushort      __ovld __conv intel_sub_group_scan_inclusive_min( ushort  x );
+@@ -15714,16 +17784,22 @@ ushort      __ovld __conv intel_sub_group_scan_inclusive_min( ushort  x );
  short       __ovld __conv intel_sub_group_scan_inclusive_max( short   x );
  ushort      __ovld __conv intel_sub_group_scan_inclusive_max( ushort  x );
  
@@ -6514,7 +6516,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  uint       __ovld __conv intel_sub_group_block_read_ui( const __global uint* p );
-@@ -15731,16 +17804,22 @@ uint2      __ovld __conv intel_sub_group_block_read_ui2( const __global uint* p
+@@ -15731,16 +17807,22 @@ uint2      __ovld __conv intel_sub_group_block_read_ui2( const __global uint* p
  uint4      __ovld __conv intel_sub_group_block_read_ui4( const __global uint* p );
  uint8      __ovld __conv intel_sub_group_block_read_ui8( const __global uint* p );
  
@@ -6537,7 +6539,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  void       __ovld __conv intel_sub_group_block_write_ui( __global uint* p, uint data );
-@@ -15748,16 +17827,22 @@ void       __ovld __conv intel_sub_group_block_write_ui2( __global uint* p, uint
+@@ -15748,16 +17830,22 @@ void       __ovld __conv intel_sub_group_block_write_ui2( __global uint* p, uint
  void       __ovld __conv intel_sub_group_block_write_ui4( __global uint* p, uint4 data );
  void       __ovld __conv intel_sub_group_block_write_ui8( __global uint* p, uint8 data );
  
@@ -6560,7 +6562,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  ushort      __ovld __conv intel_sub_group_block_read_us(  const __global ushort* p );
-@@ -15765,16 +17850,22 @@ ushort2     __ovld __conv intel_sub_group_block_read_us2( const __global ushort*
+@@ -15765,16 +17853,22 @@ ushort2     __ovld __conv intel_sub_group_block_read_us2( const __global ushort*
  ushort4     __ovld __conv intel_sub_group_block_read_us4( const __global ushort* p );
  ushort8     __ovld __conv intel_sub_group_block_read_us8( const __global ushort* p );
  
@@ -6583,7 +6585,7 @@ index d3ae0dd503..2782e5bf5d 100644
  #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
  
  void        __ovld __conv intel_sub_group_block_write_us(  __global ushort* p, ushort  data );
-@@ -15893,6 +17984,7 @@ short2 __ovld intel_sub_group_avc_ime_adjust_ref_offset(
+@@ -15893,6 +17987,7 @@ short2 __ovld intel_sub_group_avc_ime_adjust_ref_offset(
      short2 ref_offset, ushort2 src_coord, ushort2 ref_window_size,
      ushort2 image_size);
  
@@ -6591,7 +6593,7 @@ index d3ae0dd503..2782e5bf5d 100644
  intel_sub_group_avc_ime_result_t __ovld
  intel_sub_group_avc_ime_evaluate_with_single_reference(
      read_only image2d_t src_image, read_only image2d_t ref_image,
-@@ -15933,6 +18025,7 @@ intel_sub_group_avc_ime_evaluate_with_dual_reference_streaminout(
+@@ -15933,6 +18028,7 @@ intel_sub_group_avc_ime_evaluate_with_dual_reference_streaminout(
      read_only image2d_t bwd_ref_image, sampler_t vme_media_sampler,
      intel_sub_group_avc_ime_payload_t payload,
      intel_sub_group_avc_ime_dual_reference_streamin_t streamin_components);
@@ -6599,7 +6601,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  intel_sub_group_avc_ime_single_reference_streamin_t __ovld
  intel_sub_group_avc_ime_get_single_reference_streamin(
-@@ -15997,6 +18090,7 @@ intel_sub_group_avc_ref_payload_t __ovld
+@@ -15997,6 +18093,7 @@ intel_sub_group_avc_ref_payload_t __ovld
  intel_sub_group_avc_ref_set_bilinear_filter_enable(
      intel_sub_group_avc_ref_payload_t payload);
  
@@ -6607,7 +6609,7 @@ index d3ae0dd503..2782e5bf5d 100644
  intel_sub_group_avc_ref_result_t __ovld
  intel_sub_group_avc_ref_evaluate_with_single_reference(
      read_only image2d_t src_image, read_only image2d_t ref_image,
-@@ -16015,6 +18109,7 @@ intel_sub_group_avc_ref_evaluate_with_multi_reference(
+@@ -16015,6 +18112,7 @@ intel_sub_group_avc_ref_evaluate_with_multi_reference(
      read_only image2d_t src_image, uint packed_reference_ids,
      uchar packed_reference_field_polarities, sampler_t vme_media_sampler,
      intel_sub_group_avc_ref_payload_t payload);
@@ -6615,7 +6617,7 @@ index d3ae0dd503..2782e5bf5d 100644
  
  // SIC built-in functions
  intel_sub_group_avc_sic_payload_t __ovld
-@@ -16065,6 +18160,7 @@ intel_sub_group_avc_sic_set_block_based_raw_skip_sad(
+@@ -16065,6 +18163,7 @@ intel_sub_group_avc_sic_set_block_based_raw_skip_sad(
      uchar block_based_skip_type,
      intel_sub_group_avc_sic_payload_t payload);
  
@@ -6623,7 +6625,7 @@ index d3ae0dd503..2782e5bf5d 100644
  intel_sub_group_avc_sic_result_t __ovld
  intel_sub_group_avc_sic_evaluate_ipe(
      read_only image2d_t src_image, sampler_t vme_media_sampler,
-@@ -16087,6 +18183,7 @@ intel_sub_group_avc_sic_evaluate_with_multi_reference(
+@@ -16087,6 +18186,7 @@ intel_sub_group_avc_sic_evaluate_with_multi_reference(
      read_only image2d_t src_image, uint packed_reference_ids,
      uchar packed_reference_field_polarities, sampler_t vme_media_sampler,
      intel_sub_group_avc_sic_payload_t payload);


### PR DESCRIPTION
…lable for 3.0 and newer