### PR TITLE
Removed -dwarf-column-info flag

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -178,7 +178,6 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
   effectiveArgs.push_back("-cl-kernel-arg-info");
   effectiveArgs.push_back("-fno-validate-pch");
   effectiveArgs.push_back("-fno-caret-diagnostics");
-  effectiveArgs.push_back("-dwarf-column-info");
 
   if (std::find_if(effectiveArgs.begin(), effectiveArgs.end(),
                    [](const ArgsVector::value_type& a) {


### PR DESCRIPTION
The -dwarf-column-info flag is no longer available in Clang 11

As per review https://reviews.llvm.org/rGb0b5162fc23c55906a461366f8acef2431d951c5
The flag logic is now inverted, so debug column info is now ON by default.
Flags -gno-column-info and -gcolumn-info are created instead.