### PR TITLE
Emit text format of spir-v from opencl-clang

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -79,6 +79,11 @@ Copyright (c) Intel Corporation (2009-2017).
 #include <thread>
 #endif
 
+namespace SPIRV {
+// Use textual format for SPIRV.
+extern bool SPIRVUseTextFormat;
+} // namespace SPIRV
+
 using namespace Intel::OpenCL::ClangFE;
 
 static volatile bool lazyCCInit =
@@ -306,8 +311,10 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
     // llvm::remove_fatal_error_handler();
     err_ostream.flush();
 
-    if (success && optionsParser.hasEmitSPIRV()) {
+    if (success && (optionsParser.hasEmitSPIRV() || optionsParser.hasEmitSPIRVText())) {
       // Translate LLVM IR to SPIR-V.
+      if (optionsParser.hasEmitSPIRVText())
+        SPIRV::SPIRVUseTextFormat = true;
       llvm::StringRef LLVM_IR(static_cast<const char*>(pResult->GetIR()),
                               pResult->GetIRSize());
       std::unique_ptr<llvm::MemoryBuffer> MB = llvm::MemoryBuffer::getMemBuffer(LLVM_IR, pResult->GetIRName(), false);

--- a/opencl_clang_options.td
+++ b/opencl_clang_options.td
@@ -40,3 +40,4 @@ def target_triple : Separate<["-"], "target-triple">,  HelpText<"Specify target 
 def spir_std_1_0: Flag<["-"], "spir-std=1.0">;
 def spir_std_1_2: Flag<["-"], "spir-std=1.2">;
 def x : Separate<["-"], "x">;
+def Xclang : Separate<["-"], "Xclang">, HelpText<"Pass an additional option to clang -cc1 invocation">;

--- a/options.h
+++ b/options.h
@@ -142,7 +142,7 @@ private:
 class CompileOptionsParser {
 public:
   CompileOptionsParser(const char *pszOpenCLVersion)
-      : m_commonFilter(pszOpenCLVersion), m_emitSPIRV(false), m_optDisable(false) {}
+      : m_commonFilter(pszOpenCLVersion), m_emitSPIRV(false), m_emitSPIRVText(false), m_optDisable(false) {}
 
   //
   // Validates and prepares the effective options to pass to clang upon
@@ -171,6 +171,7 @@ public:
 
   bool hasEmitSPIRV() const { return m_emitSPIRV; }
   bool hasOptDisable() const { return m_optDisable; }
+  bool hasEmitSPIRVText() const { return m_emitSPIRVText; }
 
 private:
   OpenCLCompileOptTable m_optTbl;
@@ -179,6 +180,7 @@ private:
   llvm::SmallVector<const char *, 16> m_effectiveArgsRaw;
   std::string m_sourceName;
   bool m_emitSPIRV;
+  bool m_emitSPIRVText;
   bool m_optDisable;
 };
 

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -160,6 +160,9 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
       effectiveArgs.push_back("-debug-info-kind=line-tables-only");
       effectiveArgs.push_back("-dwarf-version=4");
       break;
+    case OPT_COMPILE_Xclang:
+      effectiveArgs.push_back((*it)->getValue());
+      break;
     }
   }
 
@@ -256,6 +259,10 @@ void CompileOptionsParser::processOptions(const char *pszOptions,
     else if (it->compare("-emit-spirv") == 0) {
       m_effectiveArgsRaw.push_back("-emit-llvm-bc");
       m_emitSPIRV = true;
+      continue;
+    }else if (it->compare("-emit-spirv-text") == 0) {
+      m_effectiveArgsRaw.push_back("-emit-llvm-bc");
+      m_emitSPIRVText = true;
       continue;
     }
     m_effectiveArgsRaw.push_back(it->c_str());


### PR DESCRIPTION
Signed-off-by: haonanya <haonan.yang@intel.com>
Emit text format of spir-v from opencl-clang. This is nice to have feature for branch-100 and branch-90.