### PR TITLE
Enable `kernel_arg_type_qual` translation workaround

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -332,6 +332,12 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       std::string Err;
       SPIRV::TranslatorOpts SPIRVOpts;
       SPIRVOpts.enableAllExtensions();
+
+      // Enable a workaround for this issue:
+      // KhronosGroup/SPIRV-LLVM-Translator/issues/1109
+      // To be disabled when implemeted without the workaround.
+      SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
+
       if (!optionsParser.hasOptDisable()) {
         SPIRVOpts.setMemToRegEnabled(true);
       }


### PR DESCRIPTION
Recently SPIRV-Translator removed translation of const kernel arg
qualifier:
KhronosGroup/SPIRV-LLVM-Translator/pull/989

It also introduced a workaround for it here:
KhronosGroup/SPIRV-LLVM-Translator/pull/1109

This change enables the workaround.