### PR TITLE
Update cl_ext_float_atomics patches

### DIFF
--- a/patches/clang/0002-Remove-__IMAGE_SUPPORT__-macro-for-SPIR.patch
+++ b/patches/clang/0002-Remove-__IMAGE_SUPPORT__-macro-for-SPIR.patch
@@ -1,21 +1,21 @@
-From b94b18c20953638dd3e879b72550227e58a320f8 Mon Sep 17 00:00:00 2001
+From c6d8168c10e50e64e378a5de3a9d6754f0033fa9 Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
-Date: Sat, 8 May 2021 15:14:49 +0800
+Date: Thu, 12 Aug 2021 17:06:56 +0800
 Subject: [PATCH] Remove __IMAGE_SUPPORT__ macro for SPIR since SPIR doesn't
  require image support
 
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
  clang/lib/Frontend/InitPreprocessor.cpp     | 3 ---
- clang/test/Preprocessor/predefined-macros.c | 2 --
- 2 files changed, 5 deletions(-)
+ clang/test/Preprocessor/predefined-macros.c | 1 -
+ 2 files changed, 4 deletions(-)
 
 diff --git a/clang/lib/Frontend/InitPreprocessor.cpp b/clang/lib/Frontend/InitPreprocessor.cpp
-index 6eef1e2376f6..fe0ba2cbbd69 100644
+index 5bb489c11909..cf3b48cb65d2 100644
 --- a/clang/lib/Frontend/InitPreprocessor.cpp
 +++ b/clang/lib/Frontend/InitPreprocessor.cpp
-@@ -1111,9 +1111,6 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
-   if (TI.getSupportedOpenCLOpts().isSupported(#Ext, LangOpts))                 \
+@@ -1115,9 +1115,6 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
+   if (TI.getSupportedOpenCLOpts().isSupported(#Ext))                           \
      Builder.defineMacro(#Ext);
  #include "clang/Basic/OpenCLExtensions.def"
 -
@@ -25,10 +25,10 @@ index 6eef1e2376f6..fe0ba2cbbd69 100644
  
    if (TI.hasInt128Type() && LangOpts.CPlusPlus && LangOpts.GNUMode) {
 diff --git a/clang/test/Preprocessor/predefined-macros.c b/clang/test/Preprocessor/predefined-macros.c
-index 083f0e539d88..b75589ee4fdc 100644
+index 6c80517ec4d4..d82d8b8730c0 100644
 --- a/clang/test/Preprocessor/predefined-macros.c
 +++ b/clang/test/Preprocessor/predefined-macros.c
-@@ -173,14 +173,12 @@
+@@ -186,7 +186,6 @@
  
  // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spir-unknown-unknown \
  // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIR
@@ -36,13 +36,6 @@ index 083f0e539d88..b75589ee4fdc 100644
  // CHECK-SPIR-DAG: #define __SPIR__ 1
  // CHECK-SPIR-DAG: #define __SPIR32__ 1
  // CHECK-SPIR-NOT: #define __SPIR64__ 1
- 
- // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spir64-unknown-unknown \
- // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIR64
--// CHECK-SPIR64-DAG: #define __IMAGE_SUPPORT__ 1
- // CHECK-SPIR64-DAG: #define __SPIR__ 1
- // CHECK-SPIR64-DAG: #define __SPIR64__ 1
- // CHECK-SPIR64-NOT: #define __SPIR32__ 1
 -- 
 2.17.1
 

--- a/patches/clang/0004-OpenCL-support-cl_ext_float_atomics.patch
+++ b/patches/clang/0004-OpenCL-support-cl_ext_float_atomics.patch
@@ -1,27 +1,25 @@
-From f8e87058942bd153a0f7a165b0a3dc684e06b51b Mon Sep 17 00:00:00 2001
+From 15c8e1468997ba90943155d35475b2aaeea65f19 Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
-Date: Wed, 28 Jul 2021 13:53:41 +0800
+Date: Fri, 13 Aug 2021 10:10:36 +0800
 Subject: [PATCH] [OpenCL] support cl_ext_float_atomics
 
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
- clang/lib/Headers/opencl-c-base.h     |  25 ++++
- clang/lib/Headers/opencl-c.h          | 195 ++++++++++++++++++++++++++
- clang/test/Headers/opencl-c-header.cl |  85 +++++++++++
- 3 files changed, 305 insertions(+)
+ clang/lib/Headers/opencl-c-base.h     |  22 +++
+ clang/lib/Headers/opencl-c.h          | 236 ++++++++++++++++++++++++++
+ clang/test/Headers/opencl-c-header.cl |  85 ++++++++++
+ 3 files changed, 343 insertions(+)
 
 diff --git a/clang/lib/Headers/opencl-c-base.h b/clang/lib/Headers/opencl-c-base.h
-index 430e07d36f62..0d0108b046d5 100644
+index afa900ab24d9..3410fcd05ea0 100644
 --- a/clang/lib/Headers/opencl-c-base.h
 +++ b/clang/lib/Headers/opencl-c-base.h
-@@ -9,6 +9,31 @@
- #ifndef _OPENCL_BASE_H_
- #define _OPENCL_BASE_H_
+@@ -14,6 +14,28 @@
+   #define CL_VERSION_3_0 300
+ #endif
  
 +#if (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
-+// For SPIR all extensions are supported.
-+#if defined(__SPIR__)
-+#define cl_ext_float_atomics
++#define cl_ext_float_atomics 1
 +#ifdef cl_khr_fp16
 +#define __opencl_c_ext_fp16_global_atomic_load_store 1
 +#define __opencl_c_ext_fp16_local_atomic_load_store 1
@@ -30,7 +28,7 @@ index 430e07d36f62..0d0108b046d5 100644
 +#define __opencl_c_ext_fp16_global_atomic_min_max 1
 +#define __opencl_c_ext_fp16_local_atomic_min_max 1
 +#endif
-+#ifdef __opencl_c_fp64
++#ifdef cl_khr_fp64 
 +#define __opencl_c_ext_fp64_global_atomic_add 1
 +#define __opencl_c_ext_fp64_local_atomic_add 1
 +#define __opencl_c_ext_fp64_global_atomic_min_max 1
@@ -40,19 +38,18 @@ index 430e07d36f62..0d0108b046d5 100644
 +#define __opencl_c_ext_fp32_local_atomic_add 1
 +#define __opencl_c_ext_fp32_global_atomic_min_max 1
 +#define __opencl_c_ext_fp32_local_atomic_min_max 1
-+#endif // defined(__SPIR__)
 +#endif // (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
 +
- // built-in scalar data types:
- 
- /**
+ // Define features for 2.0 for header backward compatibility
+ #ifndef __opencl_c_int64
+   #define __opencl_c_int64 1
 diff --git a/clang/lib/Headers/opencl-c.h b/clang/lib/Headers/opencl-c.h
-index 66e18bdd47bb..a853fba1482e 100644
+index 67d900eb1c3d..70264ef80d5e 100644
 --- a/clang/lib/Headers/opencl-c.h
 +++ b/clang/lib/Headers/opencl-c.h
-@@ -13529,6 +13529,201 @@ intptr_t __ovld atomic_fetch_max_explicit(volatile atomic_intptr_t *object, uint
- intptr_t __ovld atomic_fetch_max_explicit(volatile atomic_intptr_t *object, uintptr_t opermax, memory_order minder, memory_scope scope);
- #endif
+@@ -14354,6 +14354,242 @@ intptr_t __ovld atomic_fetch_max_explicit(
+        // defined(cl_khr_int64_extended_atomics)
+ #endif // (__OPENCL_C_VERSION__ >= CL_VERSION_3_0)
  
 +#if defined(cl_ext_float_atomics)
 +
@@ -71,7 +68,8 @@ index 66e18bdd47bb..a853fba1482e 100644
 +float __ovld atomic_fetch_max_explicit(volatile __global atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp32_global_atomic_min_max)
++
 +#if defined(__opencl_c_ext_fp32_local_atomic_min_max)
 +float __ovld atomic_fetch_min(volatile __local atomic_float *object,
 +                              float operand);
@@ -87,8 +85,9 @@ index 66e18bdd47bb..a853fba1482e 100644
 +float __ovld atomic_fetch_max_explicit(volatile __local atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp32_global_atomic_min_max) ||                      \
++#endif // defined(__opencl_c_ext_fp32_local_atomic_min_max)
++
++#if defined(__opencl_c_ext_fp32_global_atomic_min_max) &&                      \
 +    defined(__opencl_c_ext_fp32_local_atomic_min_max)
 +float __ovld atomic_fetch_min(volatile atomic_float *object, float operand);
 +float __ovld atomic_fetch_max(volatile atomic_float *object, float operand);
@@ -102,8 +101,12 @@ index 66e18bdd47bb..a853fba1482e 100644
 +float __ovld atomic_fetch_max_explicit(volatile atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_global_atomic_min_max)
++#endif // defined(__opencl_c_ext_fp32_global_atomic_min_max) &&                      \
++    defined(__opencl_c_ext_fp32_local_atomic_min_max)
++
++#if defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                      \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_min(volatile __global atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_max(volatile __global atomic_double *object,
@@ -118,8 +121,13 @@ index 66e18bdd47bb..a853fba1482e 100644
 +double __ovld atomic_fetch_max_explicit(volatile __global atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_local_atomic_min_max)
++#endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_local_atomic_min_max) &&                       \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_min(volatile __local atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_max(volatile __local atomic_double *object,
@@ -134,9 +142,14 @@ index 66e18bdd47bb..a853fba1482e 100644
 +double __ovld atomic_fetch_max_explicit(volatile __local atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_global_atomic_min_max) ||                      \
-+    defined(__opencl_c_ext_fp64_local_atomic_min_max)
++#endif // defined(__opencl_c_ext_fp64_local_atomic_min_max) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                      \
++    defined(__opencl_c_ext_fp64_local_atomic_min_max) &&                       \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_min(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_max(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_min_explicit(volatile atomic_double *object,
@@ -149,7 +162,10 @@ index 66e18bdd47bb..a853fba1482e 100644
 +double __ovld atomic_fetch_max_explicit(volatile atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&
++       // defined(__opencl_c_ext_fp64_local_atomic_min_max) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
 +#if defined(__opencl_c_ext_fp32_global_atomic_add)
 +float __ovld atomic_fetch_add(volatile __global atomic_float *object,
@@ -166,7 +182,8 @@ index 66e18bdd47bb..a853fba1482e 100644
 +float __ovld atomic_fetch_sub_explicit(volatile __global atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp32_global_atomic_add)
++
 +#if defined(__opencl_c_ext_fp32_local_atomic_add)
 +float __ovld atomic_fetch_add(volatile __local atomic_float *object,
 +                              float operand);
@@ -182,9 +199,12 @@ index 66e18bdd47bb..a853fba1482e 100644
 +float __ovld atomic_fetch_sub_explicit(volatile __local atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp32_global_atomic_add) ||                          \
-+    defined(__opencl_c_ext_fp32_local_atomic_add)
++#endif // defined(__opencl_c_ext_fp32_local_atomic_add)
++
++#if defined(__opencl_c_ext_fp32_global_atomic_add) &&                          \
++    defined(__opencl_c_ext_fp32_local_atomic_add) &&                           \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +float __ovld atomic_fetch_add(volatile atomic_float *object, float operand);
 +float __ovld atomic_fetch_sub(volatile atomic_float *object, float operand);
 +float __ovld atomic_fetch_add_explicit(volatile atomic_float *object,
@@ -197,9 +217,14 @@ index 66e18bdd47bb..a853fba1482e 100644
 +float __ovld atomic_fetch_sub_explicit(volatile atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp32_global_atomic_add) &&
++       // defined(__opencl_c_ext_fp32_local_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
-+#if defined(__opencl_c_ext_fp64_global_atomic_add)
++#if defined(__opencl_c_ext_fp64_global_atomic_add) &&                          \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_add(volatile __global atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_sub(volatile __global atomic_double *object,
@@ -214,8 +239,13 @@ index 66e18bdd47bb..a853fba1482e 100644
 +double __ovld atomic_fetch_sub_explicit(volatile __global atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_local_atomic_add)
++#endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_local_atomic_add) &&                           \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_add(volatile __local atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_sub(volatile __local atomic_double *object,
@@ -230,9 +260,14 @@ index 66e18bdd47bb..a853fba1482e 100644
 +double __ovld atomic_fetch_sub_explicit(volatile __local atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_global_atomic_add) ||                          \
-+    defined(__opencl_c_ext_fp64_local_atomic_add)
++#endif // defined(__opencl_c_ext_fp64_local_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_global_atomic_add) &&                          \
++    defined(__opencl_c_ext_fp64_local_atomic_add) &&                           \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_add(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_sub(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_add_explicit(volatile atomic_double *object,
@@ -245,18 +280,21 @@ index 66e18bdd47bb..a853fba1482e 100644
 +double __ovld atomic_fetch_sub_explicit(volatile atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&
++       // defined(__opencl_c_ext_fp64_local_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
 +#endif // cl_ext_float_atomics
 +
  // atomic_store()
  
- void __ovld atomic_store(volatile atomic_int *object, int desired);
+ #if defined(__opencl_c_atomic_scope_device) &&                                 \
 diff --git a/clang/test/Headers/opencl-c-header.cl b/clang/test/Headers/opencl-c-header.cl
-index 1b151ffdd16a..78265a84ec88 100644
+index 2716076acdcf..33439f297d26 100644
 --- a/clang/test/Headers/opencl-c-header.cl
 +++ b/clang/test/Headers/opencl-c-header.cl
-@@ -95,3 +95,88 @@ global atomic_int z = ATOMIC_VAR_INIT(99);
+@@ -98,3 +98,88 @@ global atomic_int z = ATOMIC_VAR_INIT(99);
  #pragma OPENCL EXTENSION cl_intel_planar_yuv : enable
  
  // CHECK-MOD: Reading modules
@@ -296,8 +334,8 @@ index 1b151ffdd16a..78265a84ec88 100644
 +#if __opencl_c_ext_fp32_local_atomic_min_max != 1
 +#error "Incorrectly defined __opencl_c_ext_fp32_local_atomic_min_max"
 +#endif
-+
 +#else
++
 +#ifdef __opencl_c_ext_fp16_global_atomic_load_store
 +#error "Incorrectly __opencl_c_ext_fp16_global_atomic_load_store defined"
 +#endif

--- a/patches/spirv/0001-Add-support-for-cl_ext_float_atomics-in-SPIRVWriter.patch
+++ b/patches/spirv/0001-Add-support-for-cl_ext_float_atomics-in-SPIRVWriter.patch
@@ -1,95 +1,36 @@
-From 91111ac0ab72f8168344a8c878999f12768b1632 Mon Sep 17 00:00:00 2001
+From 8ba15d3b243584a005b3016fb4cd02e78a636a10 Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
 Date: Wed, 28 Jul 2021 11:43:20 +0800
 Subject: [PATCH] Add support for cl_ext_float_atomics in SPIRVWriter
 
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
- lib/SPIRV/OCLToSPIRV.cpp                | 80 +++++++++++++++++++++++--
- lib/SPIRV/OCLUtil.cpp                   | 26 --------
- lib/SPIRV/OCLUtil.h                     |  4 --
- test/negative/InvalidAtomicBuiltins.cl  | 12 +---
- test/transcoding/AtomicFAddEXTForOCL.ll | 64 ++++++++++++++++++++
- test/transcoding/AtomicFMaxEXTForOCL.ll | 64 ++++++++++++++++++++
- test/transcoding/AtomicFMinEXTForOCL.ll | 64 ++++++++++++++++++++
- 7 files changed, 269 insertions(+), 45 deletions(-)
+ lib/SPIRV/OCLToSPIRV.cpp                | 27 +++++++-
+ lib/SPIRV/OCLUtil.cpp                   | 19 +++---
+ test/AtomicBuiltinsFloat.ll             | 79 +++++++++++++++++++++++
+ test/negative/InvalidAtomicBuiltins.cl  | 20 +-----
+ test/transcoding/AtomicFAddEXTForOCL.ll | 84 +++++++++++++++++++++++++
+ test/transcoding/AtomicFMaxEXTForOCL.ll | 84 +++++++++++++++++++++++++
+ test/transcoding/AtomicFMinEXTForOCL.ll | 83 ++++++++++++++++++++++++
+ 7 files changed, 368 insertions(+), 28 deletions(-)
+ create mode 100644 test/AtomicBuiltinsFloat.ll
  create mode 100644 test/transcoding/AtomicFAddEXTForOCL.ll
  create mode 100644 test/transcoding/AtomicFMaxEXTForOCL.ll
  create mode 100644 test/transcoding/AtomicFMinEXTForOCL.ll
 
 diff --git a/lib/SPIRV/OCLToSPIRV.cpp b/lib/SPIRV/OCLToSPIRV.cpp
-index 04d51586..f00f5f7b 100644
+index d9ed4a7a..cadc2247 100644
 --- a/lib/SPIRV/OCLToSPIRV.cpp
 +++ b/lib/SPIRV/OCLToSPIRV.cpp
-@@ -421,10 +421,63 @@ void OCLToSPIRVBase::visitCallInst(CallInst &CI) {
+@@ -415,7 +415,6 @@ void OCLToSPIRVBase::visitCallInst(CallInst &CI) {
+   }
    if (DemangledName.find(kOCLBuiltinName::AtomicPrefix) == 0 ||
        DemangledName.find(kOCLBuiltinName::AtomPrefix) == 0) {
- 
--    // Compute atomic builtins do not support floating types.
--    if (CI.getType()->isFloatingPointTy() &&
--        isComputeAtomicOCLBuiltin(DemangledName))
--      return;
-+    // Compute "atom" prefixed builtins do not support floating types.
-+    if (CI.getType()->isFloatingPointTy()) {
-+      if (DemangledName.find(kOCLBuiltinName::AtomPrefix) == 0)
-+        return;
-+      // handle functions which are "atomic_" prefixed.
-+      StringRef Stem = DemangledName;
-+      Stem = Stem.drop_front(strlen("atomic_"));
-+      // FP-typed atomic_{add, sub, inc, dec, exchange, min, max, or, and, xor,
-+      // fetch_or, fetch_xor, fetch_and, fetch_or_explicit, fetch_xor_explicit,
-+      // fetch_and_explicit} should be identified as function call
-+      bool IsFunctionCall = llvm::StringSwitch<bool>(Stem)
-+                                .Case("add", true)
-+                                .Case("sub", true)
-+                                .Case("inc", true)
-+                                .Case("dec", true)
-+                                .Case("cmpxchg", true)
-+                                .Case("min", true)
-+                                .Case("max", true)
-+                                .Case("or", true)
-+                                .Case("xor", true)
-+                                .Case("and", true)
-+                                .Case("fetch_or", true)
-+                                .Case("fetch_and", true)
-+                                .Case("fetch_xor", true)
-+                                .Case("fetch_or_explicit", true)
-+                                .Case("fetch_xor_explicit", true)
-+                                .Case("fetch_and_explicit", true)
-+                                .Default(false);
-+      if (IsFunctionCall)
-+        return;
-+      if (F->arg_size() != 2) {
-+        IsFunctionCall = llvm::StringSwitch<bool>(Stem)
-+                             .Case("exchange", true)
-+                             .Case("fetch_add", true)
-+                             .Case("fetch_sub", true)
-+                             .Case("fetch_min", true)
-+                             .Case("fetch_max", true)
-+                             .Case("load", true)
-+                             .Case("store", true)
-+                             .Default(false);
-+        if (IsFunctionCall)
-+          return;
-+      }
-+      if (F->arg_size() != 3 && F->arg_size() != 4) {
-+        IsFunctionCall = llvm::StringSwitch<bool>(Stem)
-+                             .Case("exchange_explicit", true)
-+                             .Case("fetch_add_explicit", true)
-+                             .Case("fetch_sub_explicit", true)
-+                             .Case("fetch_min_explicit", true)
-+                             .Case("fetch_max_explicit", true)
-+                             .Case("load_explicit", true)
-+                             .Case("store_explicit", true)
-+                             .Default(false);
-+        if (IsFunctionCall)
-+          return;
-+      }
-+    }
- 
-     auto PCI = &CI;
-     if (DemangledName == kOCLBuiltinName::AtomicInit) {
-@@ -839,7 +892,7 @@ void OCLToSPIRVBase::transAtomicBuiltin(CallInst *CI,
+-
+     // Compute atomic builtins do not support floating types.
+     if (CI.getType()->isFloatingPointTy() &&
+         isComputeAtomicOCLBuiltin(DemangledName))
+@@ -834,7 +833,7 @@ void OCLToSPIRVBase::transAtomicBuiltin(CallInst *CI,
    AttributeList Attrs = CI->getCalledFunction()->getAttributes();
    mutateCallInstSPIRV(
        M, CI,
@@ -98,7 +39,7 @@ index 04d51586..f00f5f7b 100644
          Info.PostProc(Args);
          // Order of args in OCL20:
          // object, 0-2 other args, 1-2 order, scope
-@@ -868,7 +921,22 @@ void OCLToSPIRVBase::transAtomicBuiltin(CallInst *CI,
+@@ -863,7 +862,29 @@ void OCLToSPIRVBase::transAtomicBuiltin(CallInst *CI,
            std::rotate(Args.begin() + 2, Args.begin() + OrderIdx,
                        Args.end() - Offset);
          }
@@ -114,68 +55,153 @@ index 04d51586..f00f5f7b 100644
 +            getSPIRVFuncName(OCLSPIRVBuiltinMap::map(Info.UniqName));
 +        if (!IsFPType(AtomicBuiltinsReturnType))
 +          return SPIRVFunctionName;
-+        // Translate FP-typed atomic builtins.
-+        return llvm::StringSwitch<std::string>(SPIRVFunctionName)
-+            .Case("__spirv_AtomicIAdd", "__spirv_AtomicFAddEXT")
-+            .Case("__spirv_AtomicSMax", "__spirv_AtomicFMaxEXT")
-+            .Case("__spirv_AtomicSMin", "__spirv_AtomicFMinEXT");
++        // Translate FP-typed atomic builtins. Currently we only need to
++        // translate atomic_fetch_[add, max, min] and atomic_fetch_[add, max,
++        // min]_explicit to related float instructions
++        auto SPIRFunctionNameForFloatAtomics =
++            llvm::StringSwitch<std::string>(SPIRVFunctionName)
++                .Case("__spirv_AtomicIAdd", "__spirv_AtomicFAddEXT")
++                .Case("__spirv_AtomicSMax", "__spirv_AtomicFMaxEXT")
++                .Case("__spirv_AtomicSMin", "__spirv_AtomicFMinEXT")
++                .Default("others");
++        return SPIRFunctionNameForFloatAtomics == "others"
++                   ? SPIRVFunctionName
++                   : SPIRFunctionNameForFloatAtomics;
        },
        &Attrs);
  }
 diff --git a/lib/SPIRV/OCLUtil.cpp b/lib/SPIRV/OCLUtil.cpp
-index 87f64820..e33ea30e 100644
+index 2de3f152..2150a991 100644
 --- a/lib/SPIRV/OCLUtil.cpp
 +++ b/lib/SPIRV/OCLUtil.cpp
-@@ -655,32 +655,6 @@ size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC) {
+@@ -662,29 +662,32 @@ size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC) {
    return 1;
  }
  
--bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
--  if (!DemangledName.startswith(kOCLBuiltinName::AtomicPrefix) &&
--      !DemangledName.startswith(kOCLBuiltinName::AtomPrefix))
--    return false;
--
--  return llvm::StringSwitch<bool>(DemangledName)
++// atomic_fetch_[add, sub, min, max] and atomic_fetch_[add, sub, min,
++// max]_explicit functions are defined on OpenCL headers, they are not
++// translated to function call
+ bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
+   if (!DemangledName.startswith(kOCLBuiltinName::AtomicPrefix) &&
+       !DemangledName.startswith(kOCLBuiltinName::AtomPrefix))
+     return false;
+ 
+   return llvm::StringSwitch<bool>(DemangledName)
 -      .EndsWith("add", true)
 -      .EndsWith("sub", true)
--      .EndsWith("inc", true)
--      .EndsWith("dec", true)
--      .EndsWith("cmpxchg", true)
++      .EndsWith("atomic_add", true)
++      .EndsWith("atomic_sub", true)
++      .EndsWith("atomic_min", true)
++      .EndsWith("atomic_max", true)
++      .EndsWith("atom_add", true)
++      .EndsWith("atom_sub", true)
++      .EndsWith("atom_min", true)
++      .EndsWith("atom_max", true)
+       .EndsWith("inc", true)
+       .EndsWith("dec", true)
+       .EndsWith("cmpxchg", true)
 -      .EndsWith("min", true)
 -      .EndsWith("max", true)
--      .EndsWith("and", true)
--      .EndsWith("or", true)
--      .EndsWith("xor", true)
+       .EndsWith("and", true)
+       .EndsWith("or", true)
+       .EndsWith("xor", true)
 -      .EndsWith("add_explicit", true)
 -      .EndsWith("sub_explicit", true)
--      .EndsWith("or_explicit", true)
--      .EndsWith("xor_explicit", true)
--      .EndsWith("and_explicit", true)
+       .EndsWith("or_explicit", true)
+       .EndsWith("xor_explicit", true)
+       .EndsWith("and_explicit", true)
 -      .EndsWith("min_explicit", true)
 -      .EndsWith("max_explicit", true)
--      .Default(false);
--}
--
- BarrierLiterals getBarrierLiterals(CallInst *CI) {
-   auto N = CI->getNumArgOperands();
-   assert(N == 1 || N == 2);
-diff --git a/lib/SPIRV/OCLUtil.h b/lib/SPIRV/OCLUtil.h
-index f4202405..2115a4af 100644
---- a/lib/SPIRV/OCLUtil.h
-+++ b/lib/SPIRV/OCLUtil.h
-@@ -393,10 +393,6 @@ size_t getAtomicBuiltinNumMemoryOrderArgs(StringRef Name);
- /// Get number of memory order arguments for spirv atomic builtin function.
- size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC);
+       .Default(false);
+ }
  
--/// Return true for OpenCL builtins which do compute operations
--/// (like add, sub, min, max, inc, dec, ...) atomically
--bool isComputeAtomicOCLBuiltin(StringRef DemangledName);
--
- /// Get OCL version from metadata opencl.ocl.version.
- /// \param AllowMulti Allows multiple operands if true.
- /// \return OCL version encoded as Major*10^5+Minor*10^3+Rev,
+diff --git a/test/AtomicBuiltinsFloat.ll b/test/AtomicBuiltinsFloat.ll
+new file mode 100644
+index 00000000..d75bd012
+--- /dev/null
++++ b/test/AtomicBuiltinsFloat.ll
+@@ -0,0 +1,79 @@
++; Check that translator generate atomic instructions for atomic builtins
++; RUN: llvm-as %s -o %t.bc
++; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
++; RUN: llvm-spirv %t.bc -o %t.spv
++; RUN: spirv-val %t.spv
++
++; CHECK-LABEL: Label
++; CHECK: Store
++; CHECK-COUNT-3: AtomicStore
++; CHECK-COUNT-3: AtomicLoad
++; CHECK-COUNT-3: AtomicExchange
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
++target triple = "spir-unknown-unknown"
++
++; Function Attrs: convergent norecurse nounwind
++define spir_kernel void @test_atomic_kernel(float addrspace(3)* %ff, float addrspace(3)* nocapture readnone %a) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
++entry:
++  %0 = addrspacecast float addrspace(3)* %ff to float addrspace(4)*
++  tail call spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
++  tail call spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
++  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
++  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
++  %call = tail call spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(float addrspace(4)* %0) #2
++  %call1 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(float addrspace(4)* %0, i32 0) #2
++  %call2 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(float addrspace(4)* %0, i32 0, i32 1) #2
++  %call3 = tail call spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
++  %call4 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
++  %call5 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
++  ret void
++}
++
++; Function Attrs: convergent
++declare spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(float addrspace(4)*) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(float addrspace(4)*, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(float addrspace(4)*, i32, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
++
++attributes #0 = { convergent norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #2 = { convergent nounwind }
++
++!llvm.module.flags = !{!0}
++!opencl.ocl.version = !{!1}
++!opencl.spir.version = !{!1}
++!llvm.ident = !{!2}
++
++!0 = !{i32 1, !"wchar_size", i32 4}
++!1 = !{i32 2, i32 0}
++!2 = !{!"clang version 11.1.0 (https://github.com/llvm/llvm-project.git 15c8e1468997ba90943155d35475b2aaeea65f19)"}
++!3 = !{i32 3, i32 3}
++!4 = !{!"none", !"none"}
++!5 = !{!"atomic_float*", !"float*"}
++!6 = !{!"_Atomic(float)*", !"float*"}
++!7 = !{!"volatile", !""}
 diff --git a/test/negative/InvalidAtomicBuiltins.cl b/test/negative/InvalidAtomicBuiltins.cl
-index b8ec5b89..23dcc4e3 100644
+index b8ec5b89..18d11bf5 100644
 --- a/test/negative/InvalidAtomicBuiltins.cl
 +++ b/test/negative/InvalidAtomicBuiltins.cl
 @@ -1,7 +1,9 @@
@@ -189,10 +215,17 @@ index b8ec5b89..23dcc4e3 100644
  // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
  // RUN: llvm-spirv %t.bc -o %t.spv
  // RUN: spirv-val %t.spv
-@@ -41,13 +43,9 @@ float __attribute__((overloadable)) atomic_fetch_xor(volatile generic atomic_flo
+@@ -34,20 +36,12 @@ double __attribute__((overloadable)) atom_and(volatile __global double *p, doubl
+ double __attribute__((overloadable)) atom_or(volatile __global double *p, double val);
+ double __attribute__((overloadable)) atom_xor(volatile __global double *p, double val);
+ 
+-float __attribute__((overloadable)) atomic_fetch_add(volatile generic atomic_float *object, float operand, memory_order order);
+-float __attribute__((overloadable)) atomic_fetch_sub(volatile generic atomic_float *object, float operand, memory_order order);
+ float __attribute__((overloadable)) atomic_fetch_or(volatile generic atomic_float *object, float operand, memory_order order);
+ float __attribute__((overloadable)) atomic_fetch_xor(volatile generic atomic_float *object, float operand, memory_order order);
  double __attribute__((overloadable)) atomic_fetch_and(volatile generic atomic_double *object, double operand, memory_order order);
- double __attribute__((overloadable)) atomic_fetch_max(volatile generic atomic_double *object, double operand, memory_order order);
- double __attribute__((overloadable)) atomic_fetch_min(volatile generic atomic_double *object, double operand, memory_order order);
+-double __attribute__((overloadable)) atomic_fetch_max(volatile generic atomic_double *object, double operand, memory_order order);
+-double __attribute__((overloadable)) atomic_fetch_min(volatile generic atomic_double *object, double operand, memory_order order);
 -float __attribute__((overloadable)) atomic_fetch_add_explicit(volatile generic atomic_float *object, float operand, memory_order order);
 -float __attribute__((overloadable)) atomic_fetch_sub_explicit(volatile generic atomic_float *object, float operand, memory_order order);
  float __attribute__((overloadable)) atomic_fetch_or_explicit(volatile generic atomic_float *object, float operand, memory_order order);
@@ -203,10 +236,17 @@ index b8ec5b89..23dcc4e3 100644
  
  __kernel void test_atomic_fn(volatile __global float *p,
                               volatile __global double *pp,
-@@ -86,11 +84,7 @@ __kernel void test_atomic_fn(volatile __global float *p,
+@@ -79,18 +73,10 @@ __kernel void test_atomic_fn(volatile __global float *p,
+     d = atom_or(pp, val);
+     d = atom_xor(pp, val);
+ 
+-    f = atomic_fetch_add(p, val, order);
+-    f = atomic_fetch_sub(p, val, order);
+     f = atomic_fetch_or(p, val, order);
+     f = atomic_fetch_xor(p, val, order);
      d = atomic_fetch_and(pp, val, order);
-     d = atomic_fetch_min(pp, val, order);
-     d = atomic_fetch_max(pp, val, order);
+-    d = atomic_fetch_min(pp, val, order);
+-    d = atomic_fetch_max(pp, val, order);
 -    f = atomic_fetch_add_explicit(p, val, order);
 -    f = atomic_fetch_sub_explicit(p, val, order);
      f = atomic_fetch_or_explicit(p, val, order);
@@ -217,10 +257,10 @@ index b8ec5b89..23dcc4e3 100644
  }
 diff --git a/test/transcoding/AtomicFAddEXTForOCL.ll b/test/transcoding/AtomicFAddEXTForOCL.ll
 new file mode 100644
-index 00000000..fb146fb9
+index 00000000..58d43b85
 --- /dev/null
 +++ b/test/transcoding/AtomicFAddEXTForOCL.ll
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,84 @@
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_add -o %t.spv
 +; RUN: spirv-val %t.spv
@@ -242,39 +282,59 @@ index 00000000..fb146fb9
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_32:[0-9]+]] 32
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_64:[0-9]+]] 64
 +
-+
-+; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_atomic_float(float addrspace(1)* %a) local_unnamed_addr #0 {
++; Function Attrs: convergent nounwind
++define spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_32]]
++  %call = tail call spir_func float @_Z16atomic_fetch_addPU3AS1VU7_Atomicff(float addrspace(1)* %a, float 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_32]]
 +  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_add_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFAddEXT[[:alnum:]]+fiif]]({{.*}})
-+  %call = tail call spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_32]]
++  %call2 = tail call spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)* %a, float 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func float @_Z16atomic_fetch_addPU3AS1VU7_Atomicff(float addrspace(1)*, float) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)*, float, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +
-+; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_atomic_double(double addrspace(1)* %a) local_unnamed_addr #0 {
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)*, float, i32, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent nounwind
++define spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_64]]
++  %call = tail call spir_func double @_Z16atomic_fetch_addPU3AS1VU7_Atomicdd(double addrspace(1)* %a, double 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_64]]
 +  ; CHECK-LLVM-CL20: call spir_func double @[[DOUBLE_FUNC_NAME:_Z25atomic_fetch_add_explicit[[:alnum:]]+_Atomicdd[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func double @[[DOUBLE_FUNC_NAME:_Z21__spirv_AtomicFAddEXT[[:alnum:]]+diid]]({{.*}})
-+  %call = tail call spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_64]]
++  %call2 = tail call spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)* %a, double 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func double @_Z16atomic_fetch_addPU3AS1VU7_Atomicdd(double addrspace(1)*, double) local_unnamed_addr #1
++
 +; Function Attrs: convergent
 +declare spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)*, double, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
++; Function Attrs: convergent
++declare spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)*, double, i32, i32) local_unnamed_addr #1
++
 +; CHECK-LLVM-CL: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +; CHECK-LLVM-CL: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
-+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
++attributes #0 = { convergent norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
 +
 +!llvm.module.flags = !{!0}
@@ -284,13 +344,13 @@ index 00000000..fb146fb9
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 94aa388f0ce0723bb15503cf41c2c15b288375b9)"}
++!2 = !{!"clang version 11.1.0 (4989da43e3648ed25a272773165367f195d3b53c)"}
 diff --git a/test/transcoding/AtomicFMaxEXTForOCL.ll b/test/transcoding/AtomicFMaxEXTForOCL.ll
 new file mode 100644
-index 00000000..1f2530d9
+index 00000000..417fc635
 --- /dev/null
 +++ b/test/transcoding/AtomicFMaxEXTForOCL.ll
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,84 @@
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 +; RUN: spirv-val %t.spv
@@ -312,39 +372,59 @@ index 00000000..1f2530d9
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_32:[0-9]+]] 32
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_64:[0-9]+]] 64
 +
-+; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
++; Function Attrs: convergent nounwind
++define spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_32]]
++  %call = tail call spir_func float @_Z16atomic_fetch_maxPU3AS1VU7_Atomicff(float addrspace(1)* %a, float 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_32]]
 +  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_max_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFMaxEXT[[:alnum:]]+fiif]]({{.*}})
-+  %call = tail call spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_32]]
++  %call2 = tail call spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)* %a, float 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func float @_Z16atomic_fetch_maxPU3AS1VU7_Atomicff(float addrspace(1)*, float) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)*, float, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +
-+; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)*, float, i32, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent nounwind
++define spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_64]]
++  %call = tail call spir_func double @_Z16atomic_fetch_maxPU3AS1VU7_Atomicdd(double addrspace(1)* %a, double 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_64]]
 +  ; CHECK-LLVM-CL20: call spir_func double @[[DOUBLE_FUNC_NAME:_Z25atomic_fetch_max_explicit[[:alnum:]]+_Atomicdd[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func double @[[DOUBLE_FUNC_NAME:_Z21__spirv_AtomicFMaxEXT[[:alnum:]]+diid]]({{.*}})
-+  %call = tail call spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_64]]
++  %call2 = tail call spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)* %a, double 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func double @_Z16atomic_fetch_maxPU3AS1VU7_Atomicdd(double addrspace(1)*, double) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)*, double, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
++; Function Attrs: convergent
++declare spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)*, double, i32, i32) local_unnamed_addr #1
++
 +; CHECK-LLVM-CL: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +; CHECK-LLVM-CL: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
-+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
++attributes #0 = { convergent norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
 +
 +!llvm.module.flags = !{!0}
@@ -354,13 +434,13 @@ index 00000000..1f2530d9
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 94aa388f0ce0723bb15503cf41c2c15b288375b9)"}
++!2 = !{!"clang version 11.1.0 (4989da43e3648ed25a272773165367f195d3b53c)"}
 diff --git a/test/transcoding/AtomicFMinEXTForOCL.ll b/test/transcoding/AtomicFMinEXTForOCL.ll
 new file mode 100644
-index 00000000..6196b0f8
+index 00000000..54d4dc37
 --- /dev/null
 +++ b/test/transcoding/AtomicFMinEXTForOCL.ll
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,83 @@
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 +; RUN: spirv-val %t.spv
@@ -382,39 +462,58 @@ index 00000000..6196b0f8
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_32:[0-9]+]] 32
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_64:[0-9]+]] 64
 +
-+; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
++; Function Attrs: convergent nounwind
++define spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_32]]
++  %call = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
 +  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_32]]
 +  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_min_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFMinEXT[[:alnum:]]+fiif]]({{.*}})
-+  %call = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_32]]
++  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_min_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
++  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFMinEXT[[:alnum:]]+fiif]]({{.*}})
++  %call2 = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)* %a, float 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
 +
 +; Function Attrs: convergent
 +declare spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)*, float, i32, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +
-+; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
++; Function Attrs: convergent nounwind
++define spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_64]]
++  %call = tail call spir_func double @_Z16atomic_fetch_minPU3AS1VU7_Atomicdd(double addrspace(1)* %a, double 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_64]]
 +  ; CHECK-LLVM-CL20: call spir_func double @[[DOUBLE_FUNC_NAME:_Z25atomic_fetch_min_explicit[[:alnum:]]+_Atomicdd[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func double @[[DOUBLE_FUNC_NAME:_Z21__spirv_AtomicFMinEXT[[:alnum:]]+diid]]({{.*}})
-+  %call = tail call spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_64]]
++  %call2 = tail call spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)* %a, double 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func double @_Z16atomic_fetch_minPU3AS1VU7_Atomicdd(double addrspace(1)*, double) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)*, double, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
++; Function Attrs: convergent
++declare spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)*, double, i32, i32) local_unnamed_addr #1
++
 +; CHECK-LLVM-CL: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +; CHECK-LLVM-CL: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
-+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
++attributes #0 = { convergent norecurse nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
 +
 +!llvm.module.flags = !{!0}
@@ -424,7 +523,7 @@ index 00000000..6196b0f8
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 94aa388f0ce0723bb15503cf41c2c15b288375b9)"}
++!2 = !{!"clang version 11.1.0 (4989da43e3648ed25a272773165367f195d3b53c)"}
 -- 
 2.17.1
 


### PR DESCRIPTION
Patches need to be regenerated since there are merge conflict on clang and
fix some bugs:
  1. Use cl_khr_int64_base_atomics and cl_khr_int64_extended_atomics to guard
  the functions using atomic_double type
  2. Fix incorrect atomic builtins translation and add related tests

Signed-off-by: haonanya <haonan.yang@intel.com>