### PR TITLE
Update cl_ext_float_atomics patch

### DIFF
--- a/patches/clang/0003-OpenCL-Support-cl_ext_float_atomics.patch
+++ b/patches/clang/0003-OpenCL-Support-cl_ext_float_atomics.patch
@@ -1,4 +1,4 @@
-From 366b6e3dde93e6a11143a9ed812bf2aafdfe4c5b Mon Sep 17 00:00:00 2001
+From e601cdf68ecb1a1ce4111a515b22a05845bb07c7 Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
 Date: Wed, 28 Jul 2021 14:20:08 +0800
 Subject: [PATCH] [OpenCL] Support cl_ext_float_atomics
@@ -6,12 +6,12 @@ Subject: [PATCH] [OpenCL] Support cl_ext_float_atomics
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
  clang/lib/Headers/opencl-c-base.h     |  19 +++
- clang/lib/Headers/opencl-c.h          | 195 ++++++++++++++++++++++++++
- clang/test/Headers/opencl-c-header.cl |  72 ++++++++++
- 3 files changed, 286 insertions(+)
+ clang/lib/Headers/opencl-c.h          | 232 ++++++++++++++++++++++++++
+ clang/test/Headers/opencl-c-header.cl |  84 ++++++++++
+ 3 files changed, 335 insertions(+)
 
 diff --git a/clang/lib/Headers/opencl-c-base.h b/clang/lib/Headers/opencl-c-base.h
-index e8dcd70377e5..c8b6d36029ec 100644
+index e8dcd70377e5..d94d64372dbb 100644
 --- a/clang/lib/Headers/opencl-c-base.h
 +++ b/clang/lib/Headers/opencl-c-base.h
 @@ -21,6 +21,25 @@
@@ -27,7 +27,7 @@ index e8dcd70377e5..c8b6d36029ec 100644
 +#define __opencl_c_ext_fp16_global_atomic_min_max 1
 +#define __opencl_c_ext_fp16_local_atomic_min_max 1
 +#endif
-+#ifdef __opencl_c_fp64
++#ifdef cl_khr_fp64
 +#define __opencl_c_ext_fp64_global_atomic_add 1
 +#define __opencl_c_ext_fp64_local_atomic_add 1
 +#define __opencl_c_ext_fp64_global_atomic_min_max 1
@@ -41,10 +41,10 @@ index e8dcd70377e5..c8b6d36029ec 100644
  #endif // (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
  
 diff --git a/clang/lib/Headers/opencl-c.h b/clang/lib/Headers/opencl-c.h
-index ab665628c8e1..6676da858d2a 100644
+index ab665628c8e1..501a04f6e82b 100644
 --- a/clang/lib/Headers/opencl-c.h
 +++ b/clang/lib/Headers/opencl-c.h
-@@ -13531,6 +13531,201 @@ intptr_t __ovld atomic_fetch_max_explicit(volatile atomic_intptr_t *object, uint
+@@ -13531,6 +13531,238 @@ intptr_t __ovld atomic_fetch_max_explicit(volatile atomic_intptr_t *object, uint
  intptr_t __ovld atomic_fetch_max_explicit(volatile atomic_intptr_t *object, uintptr_t opermax, memory_order minder, memory_scope scope);
  #endif
  
@@ -65,7 +65,8 @@ index ab665628c8e1..6676da858d2a 100644
 +float __ovld atomic_fetch_max_explicit(volatile __global atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp32_global_atomic_min_max)
++
 +#if defined(__opencl_c_ext_fp32_local_atomic_min_max)
 +float __ovld atomic_fetch_min(volatile __local atomic_float *object,
 +                              float operand);
@@ -81,8 +82,9 @@ index ab665628c8e1..6676da858d2a 100644
 +float __ovld atomic_fetch_max_explicit(volatile __local atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp32_global_atomic_min_max) ||                      \
++#endif // defined(__opencl_c_ext_fp32_local_atomic_min_max)
++
++#if defined(__opencl_c_ext_fp32_global_atomic_min_max) &&                      \
 +    defined(__opencl_c_ext_fp32_local_atomic_min_max)
 +float __ovld atomic_fetch_min(volatile atomic_float *object, float operand);
 +float __ovld atomic_fetch_max(volatile atomic_float *object, float operand);
@@ -96,8 +98,12 @@ index ab665628c8e1..6676da858d2a 100644
 +float __ovld atomic_fetch_max_explicit(volatile atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_global_atomic_min_max)
++#endif // defined(__opencl_c_ext_fp32_global_atomic_min_max) &&                      \
++    defined(__opencl_c_ext_fp32_local_atomic_min_max)
++
++#if defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                      \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_min(volatile __global atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_max(volatile __global atomic_double *object,
@@ -112,8 +118,13 @@ index ab665628c8e1..6676da858d2a 100644
 +double __ovld atomic_fetch_max_explicit(volatile __global atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_local_atomic_min_max)
++#endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_local_atomic_min_max) &&                       \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_min(volatile __local atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_max(volatile __local atomic_double *object,
@@ -128,9 +139,14 @@ index ab665628c8e1..6676da858d2a 100644
 +double __ovld atomic_fetch_max_explicit(volatile __local atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_global_atomic_min_max) ||                      \
-+    defined(__opencl_c_ext_fp64_local_atomic_min_max)
++#endif // defined(__opencl_c_ext_fp64_local_atomic_min_max) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                      \
++    defined(__opencl_c_ext_fp64_local_atomic_min_max) &&                       \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_min(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_max(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_min_explicit(volatile atomic_double *object,
@@ -143,7 +159,10 @@ index ab665628c8e1..6676da858d2a 100644
 +double __ovld atomic_fetch_max_explicit(volatile atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&
++       // defined(__opencl_c_ext_fp64_local_atomic_min_max) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
 +#if defined(__opencl_c_ext_fp32_global_atomic_add)
 +float __ovld atomic_fetch_add(volatile __global atomic_float *object,
@@ -160,7 +179,8 @@ index ab665628c8e1..6676da858d2a 100644
 +float __ovld atomic_fetch_sub_explicit(volatile __global atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp32_global_atomic_add)
++
 +#if defined(__opencl_c_ext_fp32_local_atomic_add)
 +float __ovld atomic_fetch_add(volatile __local atomic_float *object,
 +                              float operand);
@@ -176,8 +196,9 @@ index ab665628c8e1..6676da858d2a 100644
 +float __ovld atomic_fetch_sub_explicit(volatile __local atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp32_global_atomic_add) ||                          \
++#endif // defined(__opencl_c_ext_fp32_local_atomic_add)
++
++#if defined(__opencl_c_ext_fp32_global_atomic_add) &&                          \
 +    defined(__opencl_c_ext_fp32_local_atomic_add)
 +float __ovld atomic_fetch_add(volatile atomic_float *object, float operand);
 +float __ovld atomic_fetch_sub(volatile atomic_float *object, float operand);
@@ -191,9 +212,12 @@ index ab665628c8e1..6676da858d2a 100644
 +float __ovld atomic_fetch_sub_explicit(volatile atomic_float *object,
 +                                       float operand, memory_order order,
 +                                       memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp32_global_atomic_add) &&                          \
++    defined(__opencl_c_ext_fp32_local_atomic_add)
 +
-+#if defined(__opencl_c_ext_fp64_global_atomic_add)
++#if defined(__opencl_c_ext_fp64_global_atomic_add) &&                          \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_add(volatile __global atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_sub(volatile __global atomic_double *object,
@@ -208,8 +232,13 @@ index ab665628c8e1..6676da858d2a 100644
 +double __ovld atomic_fetch_sub_explicit(volatile __global atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_local_atomic_add)
++#endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_local_atomic_add) &&                           \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_add(volatile __local atomic_double *object,
 +                               double operand);
 +double __ovld atomic_fetch_sub(volatile __local atomic_double *object,
@@ -224,9 +253,14 @@ index ab665628c8e1..6676da858d2a 100644
 +double __ovld atomic_fetch_sub_explicit(volatile __local atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
-+#if defined(__opencl_c_ext_fp64_global_atomic_add) ||                          \
-+    defined(__opencl_c_ext_fp64_local_atomic_add)
++#endif // defined(__opencl_c_ext_fp64_local_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
++
++#if defined(__opencl_c_ext_fp64_global_atomic_add) &&                          \
++    defined(__opencl_c_ext_fp64_local_atomic_add) &&                           \
++    defined(cl_khr_int64_base_atomics) &&                                      \
++    defined(cl_khr_int64_extended_atomics)
 +double __ovld atomic_fetch_add(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_sub(volatile atomic_double *object, double operand);
 +double __ovld atomic_fetch_add_explicit(volatile atomic_double *object,
@@ -239,7 +273,10 @@ index ab665628c8e1..6676da858d2a 100644
 +double __ovld atomic_fetch_sub_explicit(volatile atomic_double *object,
 +                                        double operand, memory_order order,
 +                                        memory_scope scope);
-+#endif
++#endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&
++       // defined(__opencl_c_ext_fp64_local_atomic_add) &&
++       // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
 +#endif // cl_ext_float_atomics
 +
@@ -247,10 +284,10 @@ index ab665628c8e1..6676da858d2a 100644
  
  void __ovld atomic_store(volatile atomic_int *object, int desired);
 diff --git a/clang/test/Headers/opencl-c-header.cl b/clang/test/Headers/opencl-c-header.cl
-index 13a3b62481ec..2c02d14f25c3 100644
+index 13a3b62481ec..443f682c711a 100644
 --- a/clang/test/Headers/opencl-c-header.cl
 +++ b/clang/test/Headers/opencl-c-header.cl
-@@ -124,6 +124,36 @@ global atomic_int z = ATOMIC_VAR_INIT(99);
+@@ -124,6 +124,48 @@ global atomic_int z = ATOMIC_VAR_INIT(99);
  #if cl_khr_subgroup_clustered_reduce != 1
  #error "Incorrectly defined cl_khr_subgroup_clustered_reduce"
  #endif
@@ -266,11 +303,17 @@ index 13a3b62481ec..2c02d14f25c3 100644
 +#if __opencl_c_ext_fp32_global_atomic_add != 1
 +#error "Incorrectly defined __opencl_c_ext_fp32_global_atomic_add"
 +#endif
++#if __opencl_c_ext_fp64_global_atomic_add != 1
++#error "Incorrectly defined __opencl_c_ext_fp64_global_atomic_add"
++#endif
 +#if __opencl_c_ext_fp16_local_atomic_add != 1
 +#error "Incorrectly defined __opencl_c_ext_fp16_local_atomic_add"
 +#endif
 +#if __opencl_c_ext_fp32_local_atomic_add != 1
 +#error "Incorrectly defined __opencl_c_ext_fp32_local_atomic_add"
++#endif
++#if __opencl_c_ext_fp64_local_atomic_add != 1
++#error "Incorrectly defined __opencl_c_ext_fp64_local_atomic_add"
 +#endif
 +#if __opencl_c_ext_fp16_global_atomic_min_max != 1
 +#error "Incorrectly defined __opencl_c_ext_fp16_global_atomic_min_max"
@@ -278,16 +321,22 @@ index 13a3b62481ec..2c02d14f25c3 100644
 +#if __opencl_c_ext_fp32_global_atomic_min_max != 1
 +#error "Incorrectly defined __opencl_c_ext_fp32_global_atomic_min_max"
 +#endif
++#if __opencl_c_ext_fp64_global_atomic_min_max != 1
++#error "Incorrectly defined __opencl_c_ext_fp64_global_atomic_min_max"
++#endif
 +#if __opencl_c_ext_fp16_local_atomic_min_max != 1
 +#error "Incorrectly defined __opencl_c_ext_fp16_local_atomic_min_max"
 +#endif
 +#if __opencl_c_ext_fp32_local_atomic_min_max != 1
 +#error "Incorrectly defined __opencl_c_ext_fp32_local_atomic_min_max"
 +#endif
++#if __opencl_c_ext_fp64_local_atomic_min_max != 1
++#error "Incorrectly defined __opencl_c_ext_fp64_local_atomic_min_max"
++#endif
  
  #else
  
-@@ -148,6 +178,48 @@ global atomic_int z = ATOMIC_VAR_INIT(99);
+@@ -148,6 +190,48 @@ global atomic_int z = ATOMIC_VAR_INIT(99);
  #ifdef cl_khr_subgroup_clustered_reduce
  #error "Incorrect cl_khr_subgroup_clustered_reduce define"
  #endif

--- a/patches/spirv/0001-Add-support-for-cl_ext_float_atomics-in-SPIRVWriter.patch
+++ b/patches/spirv/0001-Add-support-for-cl_ext_float_atomics-in-SPIRVWriter.patch
@@ -1,4 +1,4 @@
-From b4da5aed64726cb6335d672649bdda2516dc319a Mon Sep 17 00:00:00 2001
+From 8a7885884d8b7074f716332768ed957d849b9a72 Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
 Date: Wed, 28 Jul 2021 14:24:23 +0800
 Subject: [PATCH] Add support for cl_ext_float_atomics in SPIRVWriter
@@ -6,9 +6,8 @@ Subject: [PATCH] Add support for cl_ext_float_atomics in SPIRVWriter
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
  include/LLVMSPIRVExtensions.inc        |   1 +
- lib/SPIRV/OCLToSPIRV.cpp               |  80 +++++++++++++++--
- lib/SPIRV/OCLUtil.cpp                  |  26 ------
- lib/SPIRV/OCLUtil.h                    |   4 -
+ lib/SPIRV/OCLToSPIRV.cpp               |  27 +++++-
+ lib/SPIRV/OCLUtil.cpp                  |  19 ++--
  lib/SPIRV/SPIRVToOCL.h                 |   3 +
  lib/SPIRV/SPIRVToOCL12.cpp             |  21 +++++
  lib/SPIRV/SPIRVToOCL20.cpp             |  28 +++++-
@@ -17,15 +16,17 @@ Signed-off-by: haonanya <haonan.yang@intel.com>
  lib/SPIRV/libSPIRV/SPIRVOpCode.h       |   8 +-
  lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h   |   2 +
  lib/SPIRV/libSPIRV/spirv.hpp           |   7 ++
+ test/AtomicBuiltinsFloat.ll            |  79 ++++++++++++++++
  test/AtomicFAddEXT.ll                  |  72 +++++++++++++++
- test/AtomicFAddEXTForOCL.ll            |  64 +++++++++++++
+ test/AtomicFAddEXTForOCL.ll            |  84 +++++++++++++++++
  test/AtomicFAddExt.ll                  | 119 -------------------------
  test/AtomicFMaxEXT.ll                  |  73 +++++++++++++++
- test/AtomicFMaxEXTForOCL.ll            |  64 +++++++++++++
+ test/AtomicFMaxEXTForOCL.ll            |  84 +++++++++++++++++
  test/AtomicFMinEXT.ll                  |  73 +++++++++++++++
- test/AtomicFMinEXTForOCL.ll            |  64 +++++++++++++
- test/negative/InvalidAtomicBuiltins.cl |  10 +--
- 20 files changed, 578 insertions(+), 165 deletions(-)
+ test/AtomicFMinEXTForOCL.ll            |  81 +++++++++++++++++
+ test/negative/InvalidAtomicBuiltins.cl |  18 +---
+ 20 files changed, 675 insertions(+), 148 deletions(-)
+ create mode 100644 test/AtomicBuiltinsFloat.ll
  create mode 100644 test/AtomicFAddEXT.ll
  create mode 100644 test/AtomicFAddEXTForOCL.ll
  delete mode 100644 test/AtomicFAddExt.ll
@@ -47,78 +48,18 @@ index e313a8e1..83469be1 100644
  EXT(SPV_KHR_float_controls)
  EXT(SPV_INTEL_subgroups)
 diff --git a/lib/SPIRV/OCLToSPIRV.cpp b/lib/SPIRV/OCLToSPIRV.cpp
-index f23a4372..e9cfc8d6 100644
+index 7c65b9e8..7ea350ff 100644
 --- a/lib/SPIRV/OCLToSPIRV.cpp
 +++ b/lib/SPIRV/OCLToSPIRV.cpp
-@@ -392,10 +392,63 @@ void OCLToSPIRV::visitCallInst(CallInst &CI) {
+@@ -386,7 +386,6 @@ void OCLToSPIRV::visitCallInst(CallInst &CI) {
+   }
    if (DemangledName.find(kOCLBuiltinName::AtomicPrefix) == 0 ||
        DemangledName.find(kOCLBuiltinName::AtomPrefix) == 0) {
- 
--    // Compute atomic builtins do not support floating types.
--    if (CI.getType()->isFloatingPointTy() &&
--        isComputeAtomicOCLBuiltin(DemangledName))
--      return;
-+    // Compute "atom" prefixed builtins do not support floating types.
-+    if (CI.getType()->isFloatingPointTy()) {
-+      if (DemangledName.find(kOCLBuiltinName::AtomPrefix) == 0)
-+        return;
-+      // handle functions which are "atomic_" prefixed.
-+      StringRef Stem = DemangledName;
-+      Stem = Stem.drop_front(strlen("atomic_"));
-+      // FP-typed atomic_{add, sub, inc, dec, exchange, min, max, or, and, xor,
-+      // fetch_or, fetch_xor, fetch_and, fetch_or_explicit, fetch_xor_explicit,
-+      // fetch_and_explicit} should be identified as function call
-+      bool IsFunctionCall = llvm::StringSwitch<bool>(Stem)
-+                                .Case("add", true)
-+                                .Case("sub", true)
-+                                .Case("inc", true)
-+                                .Case("dec", true)
-+                                .Case("cmpxchg", true)
-+                                .Case("min", true)
-+                                .Case("max", true)
-+                                .Case("or", true)
-+                                .Case("xor", true)
-+                                .Case("and", true)
-+                                .Case("fetch_or", true)
-+                                .Case("fetch_and", true)
-+                                .Case("fetch_xor", true)
-+                                .Case("fetch_or_explicit", true)
-+                                .Case("fetch_xor_explicit", true)
-+                                .Case("fetch_and_explicit", true)
-+                                .Default(false);
-+      if (IsFunctionCall)
-+        return;
-+      if (F->arg_size() != 2) {
-+        IsFunctionCall = llvm::StringSwitch<bool>(Stem)
-+                             .Case("exchange", true)
-+                             .Case("fetch_add", true)
-+                             .Case("fetch_sub", true)
-+                             .Case("fetch_min", true)
-+                             .Case("fetch_max", true)
-+                             .Case("load", true)
-+                             .Case("store", true)
-+                             .Default(false);
-+        if (IsFunctionCall)
-+          return;
-+      }
-+      if (F->arg_size() != 3 && F->arg_size() != 4) {
-+        IsFunctionCall = llvm::StringSwitch<bool>(Stem)
-+                             .Case("exchange_explicit", true)
-+                             .Case("fetch_add_explicit", true)
-+                             .Case("fetch_sub_explicit", true)
-+                             .Case("fetch_min_explicit", true)
-+                             .Case("fetch_max_explicit", true)
-+                             .Case("load_explicit", true)
-+                             .Case("store_explicit", true)
-+                             .Default(false);
-+        if (IsFunctionCall)
-+          return;
-+      }
-+    }
- 
-     auto PCI = &CI;
-     if (DemangledName == kOCLBuiltinName::AtomicInit) {
-@@ -803,7 +856,7 @@ void OCLToSPIRV::transAtomicBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info) {
+-
+     // Compute atomic builtins do not support floating types.
+     if (CI.getType()->isFloatingPointTy() &&
+         isComputeAtomicOCLBuiltin(DemangledName))
+@@ -798,7 +797,7 @@ void OCLToSPIRV::transAtomicBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info) {
    AttributeList Attrs = CI->getCalledFunction()->getAttributes();
    mutateCallInstSPIRV(
        M, CI,
@@ -127,7 +68,7 @@ index f23a4372..e9cfc8d6 100644
          Info.PostProc(Args);
          // Order of args in OCL20:
          // object, 0-2 other args, 1-2 order, scope
-@@ -832,7 +885,22 @@ void OCLToSPIRV::transAtomicBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info) {
+@@ -827,7 +826,29 @@ void OCLToSPIRV::transAtomicBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info) {
            std::rotate(Args.begin() + 2, Args.begin() + OrderIdx,
                        Args.end() - Offset);
          }
@@ -143,74 +84,74 @@ index f23a4372..e9cfc8d6 100644
 +            getSPIRVFuncName(OCLSPIRVBuiltinMap::map(Info.UniqName));
 +        if (!IsFPType(AtomicBuiltinsReturnType))
 +          return SPIRVFunctionName;
-+        // Translate FP-typed atomic builtins.
-+        return llvm::StringSwitch<std::string>(SPIRVFunctionName)
-+            .Case("__spirv_AtomicIAdd", "__spirv_AtomicFAddEXT")
-+            .Case("__spirv_AtomicSMax", "__spirv_AtomicFMaxEXT")
-+            .Case("__spirv_AtomicSMin", "__spirv_AtomicFMinEXT");
++        // Translate FP-typed atomic builtins. Currently we only need to
++        // translate atomic_fetch_[add, max, min] and atomic_fetch_[add, max,
++        // min]_explicit to related float instructions
++        auto SPIRFunctionNameForFloatAtomics =
++            llvm::StringSwitch<std::string>(SPIRVFunctionName)
++                .Case("__spirv_AtomicIAdd", "__spirv_AtomicFAddEXT")
++                .Case("__spirv_AtomicSMax", "__spirv_AtomicFMaxEXT")
++                .Case("__spirv_AtomicSMin", "__spirv_AtomicFMinEXT")
++                .Default("others");
++        return SPIRFunctionNameForFloatAtomics == "others"
++                   ? SPIRVFunctionName
++                   : SPIRFunctionNameForFloatAtomics;
        },
        &Attrs);
  }
 diff --git a/lib/SPIRV/OCLUtil.cpp b/lib/SPIRV/OCLUtil.cpp
-index 87f64820..e33ea30e 100644
+index 2cc5d815..e4d7a7cf 100644
 --- a/lib/SPIRV/OCLUtil.cpp
 +++ b/lib/SPIRV/OCLUtil.cpp
-@@ -655,32 +655,6 @@ size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC) {
+@@ -655,29 +655,32 @@ size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC) {
    return 1;
  }
  
--bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
--  if (!DemangledName.startswith(kOCLBuiltinName::AtomicPrefix) &&
--      !DemangledName.startswith(kOCLBuiltinName::AtomPrefix))
--    return false;
--
--  return llvm::StringSwitch<bool>(DemangledName)
++// atomic_fetch_[add, sub, min, max] and atomic_fetch_[add, sub, min,
++// max]_explicit functions are defined on OpenCL headers, they are not
++// translated to function call
+ bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
+   if (!DemangledName.startswith(kOCLBuiltinName::AtomicPrefix) &&
+       !DemangledName.startswith(kOCLBuiltinName::AtomPrefix))
+     return false;
+ 
+   return llvm::StringSwitch<bool>(DemangledName)
 -      .EndsWith("add", true)
 -      .EndsWith("sub", true)
--      .EndsWith("inc", true)
--      .EndsWith("dec", true)
--      .EndsWith("cmpxchg", true)
++      .EndsWith("atomic_add", true)
++      .EndsWith("atomic_sub", true)
++      .EndsWith("atomic_min", true)
++      .EndsWith("atomic_max", true)
++      .EndsWith("atom_add", true)
++      .EndsWith("atom_sub", true)
++      .EndsWith("atom_min", true)
++      .EndsWith("atom_max", true)
+       .EndsWith("inc", true)
+       .EndsWith("dec", true)
+       .EndsWith("cmpxchg", true)
 -      .EndsWith("min", true)
 -      .EndsWith("max", true)
--      .EndsWith("and", true)
--      .EndsWith("or", true)
--      .EndsWith("xor", true)
+       .EndsWith("and", true)
+       .EndsWith("or", true)
+       .EndsWith("xor", true)
 -      .EndsWith("add_explicit", true)
 -      .EndsWith("sub_explicit", true)
--      .EndsWith("or_explicit", true)
--      .EndsWith("xor_explicit", true)
--      .EndsWith("and_explicit", true)
+       .EndsWith("or_explicit", true)
+       .EndsWith("xor_explicit", true)
+       .EndsWith("and_explicit", true)
 -      .EndsWith("min_explicit", true)
 -      .EndsWith("max_explicit", true)
--      .Default(false);
--}
--
- BarrierLiterals getBarrierLiterals(CallInst *CI) {
-   auto N = CI->getNumArgOperands();
-   assert(N == 1 || N == 2);
-diff --git a/lib/SPIRV/OCLUtil.h b/lib/SPIRV/OCLUtil.h
-index 69545aa3..52af3f64 100644
---- a/lib/SPIRV/OCLUtil.h
-+++ b/lib/SPIRV/OCLUtil.h
-@@ -390,10 +390,6 @@ size_t getAtomicBuiltinNumMemoryOrderArgs(StringRef Name);
- /// Get number of memory order arguments for spirv atomic builtin function.
- size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC);
+       .Default(false);
+ }
  
--/// Return true for OpenCL builtins which do compute operations
--/// (like add, sub, min, max, inc, dec, ...) atomically
--bool isComputeAtomicOCLBuiltin(StringRef DemangledName);
--
- /// Get OCL version from metadata opencl.ocl.version.
- /// \param AllowMulti Allows multiple operands if true.
- /// \return OCL version encoded as Major*10^5+Minor*10^3+Rev,
 diff --git a/lib/SPIRV/SPIRVToOCL.h b/lib/SPIRV/SPIRVToOCL.h
-index b59d25e0..b55c9e4f 100644
+index 160fcf5c..31036bfa 100644
 --- a/lib/SPIRV/SPIRVToOCL.h
 +++ b/lib/SPIRV/SPIRVToOCL.h
 @@ -214,6 +214,9 @@ public:
-
+ 
    void translateOpaqueTypes();
-
+ 
 +  // Transform FP atomic opcode to corresponding OpenCL function name
 +  virtual std::string mapFPAtomicName(Op OC) = 0;
 +
@@ -218,7 +159,7 @@ index b59d25e0..b55c9e4f 100644
    /// Transform uniform group opcode to corresponding OpenCL function name,
    /// example: GroupIAdd(Reduce) => group_iadd => work_group_reduce_add |
 diff --git a/lib/SPIRV/SPIRVToOCL12.cpp b/lib/SPIRV/SPIRVToOCL12.cpp
-index f8ef5f4e..b3ed61b3 100644
+index 75fce5a1..01b23e2c 100644
 --- a/lib/SPIRV/SPIRVToOCL12.cpp
 +++ b/lib/SPIRV/SPIRVToOCL12.cpp
 @@ -104,6 +104,9 @@ public:
@@ -231,7 +172,7 @@ index f8ef5f4e..b3ed61b3 100644
    static char ID;
  };
  
-@@ -304,6 +307,21 @@ Instruction *SPIRVToOCL12::visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) {
+@@ -312,6 +315,21 @@ Instruction *SPIRVToOCL12::visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) {
    return NewCI;
  }
  
@@ -253,7 +194,7 @@ index f8ef5f4e..b3ed61b3 100644
  Instruction *SPIRVToOCL12::mutateAtomicName(CallInst *CI, Op OC) {
    AttributeList Attrs = CI->getCalledFunction()->getAttributes();
    return mutateCallInstOCL(
-@@ -317,6 +335,9 @@ Instruction *SPIRVToOCL12::mutateAtomicName(CallInst *CI, Op OC) {
+@@ -325,6 +343,9 @@ Instruction *SPIRVToOCL12::mutateAtomicName(CallInst *CI, Op OC) {
  std::string SPIRVToOCL12::mapAtomicName(Op OC, Type *Ty) {
    std::string Prefix = Ty->isIntegerTy(64) ? kOCLBuiltinName::AtomPrefix
                                             : kOCLBuiltinName::AtomicPrefix;
@@ -264,7 +205,7 @@ index f8ef5f4e..b3ed61b3 100644
  }
  
 diff --git a/lib/SPIRV/SPIRVToOCL20.cpp b/lib/SPIRV/SPIRVToOCL20.cpp
-index cfe6c3e6..34294b0d 100644
+index b6838512..b0a54c3d 100644
 --- a/lib/SPIRV/SPIRVToOCL20.cpp
 +++ b/lib/SPIRV/SPIRVToOCL20.cpp
 @@ -83,6 +83,9 @@ public:
@@ -277,7 +218,7 @@ index cfe6c3e6..34294b0d 100644
    static char ID;
  };
  
-@@ -153,11 +156,29 @@ void SPIRVToOCL20::visitCallSPIRVControlBarrier(CallInst *CI) {
+@@ -161,11 +164,29 @@ void SPIRVToOCL20::visitCallSPIRVControlBarrier(CallInst *CI) {
        &Attrs);
  }
  
@@ -307,7 +248,7 @@ index cfe6c3e6..34294b0d 100644
          return OCLSPIRVBuiltinMap::rmap(OC);
        },
        &Attrs);
-@@ -224,7 +245,12 @@ CallInst *SPIRVToOCL20::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
+@@ -232,7 +253,12 @@ CallInst *SPIRVToOCL20::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
            }
          }
          auto Ptr = findFirstPtr(Args);
@@ -442,6 +383,91 @@ index f0e311c6..2a86f32e 100644
      case OpDecorateString: *hasResult = false; *hasResultType = false; break;
      case OpMemberDecorateString: *hasResult = false; *hasResultType = false; break;
      case OpVmeImageINTEL: *hasResult = true; *hasResultType = true; break;
+diff --git a/test/AtomicBuiltinsFloat.ll b/test/AtomicBuiltinsFloat.ll
+new file mode 100644
+index 00000000..d9300558
+--- /dev/null
++++ b/test/AtomicBuiltinsFloat.ll
+@@ -0,0 +1,79 @@
++; Check that translator generate atomic instructions for atomic builtins
++; RUN: llvm-as %s -o %t.bc
++; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
++; RUN: llvm-spirv %t.bc -o %t.spv
++; RUN: spirv-val %t.spv
++
++; CHECK-LABEL: Label
++; CHECK: Store
++; CHECK-COUNT-3: AtomicStore
++; CHECK-COUNT-3: AtomicLoad
++; CHECK-COUNT-3: AtomicExchange
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
++target triple = "spir-unknown-unknown"
++
++; Function Attrs: convergent norecurse nounwind
++define dso_local spir_kernel void @test_atomic_kernel(float addrspace(3)* %ff, float addrspace(3)* nocapture readnone %a) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
++entry:
++  %0 = addrspacecast float addrspace(3)* %ff to float addrspace(4)*
++  tail call spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
++  tail call spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
++  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
++  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
++  %call = tail call spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(float addrspace(4)* %0) #2
++  %call1 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(float addrspace(4)* %0, i32 0) #2
++  %call2 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(float addrspace(4)* %0, i32 0, i32 1) #2
++  %call3 = tail call spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
++  %call4 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
++  %call5 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
++  ret void
++}
++
++; Function Attrs: convergent
++declare spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(float addrspace(4)*) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(float addrspace(4)*, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(float addrspace(4)*, i32, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
++
++attributes #0 = { convergent norecurse nounwind "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #2 = { convergent nounwind }
++
++!llvm.module.flags = !{!0}
++!opencl.ocl.version = !{!1}
++!opencl.spir.version = !{!1}
++!llvm.ident = !{!2}
++
++!0 = !{i32 1, !"wchar_size", i32 4}
++!1 = !{i32 2, i32 0}
++!2 = !{!"clang version 12.0.1 (https://github.com/llvm/llvm-project.git 23fe7b104a0adaaaecd52108105f49297c420c9b)"}
++!3 = !{i32 3, i32 3}
++!4 = !{!"none", !"none"}
++!5 = !{!"atomic_float*", !"float*"}
++!6 = !{!"_Atomic(float)*", !"float*"}
++!7 = !{!"volatile", !""}
 diff --git a/test/AtomicFAddEXT.ll b/test/AtomicFAddEXT.ll
 new file mode 100644
 index 00000000..b012c904
@@ -522,10 +548,10 @@ index 00000000..b012c904
 +!3 = !{!"clang version 13.0.0"}
 diff --git a/test/AtomicFAddEXTForOCL.ll b/test/AtomicFAddEXTForOCL.ll
 new file mode 100644
-index 00000000..fb146fb9
+index 00000000..4dc4564a
 --- /dev/null
 +++ b/test/AtomicFAddEXTForOCL.ll
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,84 @@
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_add -o %t.spv
 +; RUN: spirv-val %t.spv
@@ -547,39 +573,59 @@ index 00000000..fb146fb9
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_32:[0-9]+]] 32
 +; CHECK-SPIRV: TypeFloat [[TYPE_FLOAT_64:[0-9]+]] 64
 +
-+
 +; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_atomic_float(float addrspace(1)* %a) local_unnamed_addr #0 {
++define dso_local spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_32]]
++  %call = tail call spir_func float @_Z16atomic_fetch_addPU3AS1VU7_Atomicff(float addrspace(1)* %a, float 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_32]]
 +  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_add_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFAddEXT[[:alnum:]]+fiif]]({{.*}})
-+  %call = tail call spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_32]]
++  %call2 = tail call spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)* %a, float 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func float @_Z16atomic_fetch_addPU3AS1VU7_Atomicff(float addrspace(1)*, float) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)*, float, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)*, float, i32, i32) local_unnamed_addr #1
++
 +; Function Attrs: convergent norecurse nounwind
-+define dso_local spir_func void @test_atomic_double(double addrspace(1)* %a) local_unnamed_addr #0 {
++define dso_local spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_64]]
++  %call = tail call spir_func double @_Z16atomic_fetch_addPU3AS1VU7_Atomicdd(double addrspace(1)* %a, double 0.000000e+00) #2
 +  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_64]]
 +  ; CHECK-LLVM-CL20: call spir_func double @[[DOUBLE_FUNC_NAME:_Z25atomic_fetch_add_explicit[[:alnum:]]+_Atomicdd[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func double @[[DOUBLE_FUNC_NAME:_Z21__spirv_AtomicFAddEXT[[:alnum:]]+diid]]({{.*}})
-+  %call = tail call spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFAddEXT [[TYPE_FLOAT_64]]
++  %call2 = tail call spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)* %a, double 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func double @_Z16atomic_fetch_addPU3AS1VU7_Atomicdd(double addrspace(1)*, double) local_unnamed_addr #1
++
 +; Function Attrs: convergent
 +declare spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)*, double, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
++; Function Attrs: convergent
++declare spir_func double @_Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)*, double, i32, i32) local_unnamed_addr #1
++
 +; CHECK-LLVM-CL: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +; CHECK-LLVM-CL: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
-+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
++attributes #0 = { convergent norecurse nounwind "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
 +
 +!llvm.module.flags = !{!0}
@@ -589,7 +635,7 @@ index 00000000..fb146fb9
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 94aa388f0ce0723bb15503cf41c2c15b288375b9)"}
++!2 = !{!"clang version 12.0.1 (https://github.com/llvm/llvm-project.git 23fe7b104a0adaaaecd52108105f49297c420c9b)"}
 diff --git a/test/AtomicFAddExt.ll b/test/AtomicFAddExt.ll
 deleted file mode 100644
 index 58e9f576..00000000
@@ -796,10 +842,10 @@ index 00000000..67111c43
 +
 diff --git a/test/AtomicFMaxEXTForOCL.ll b/test/AtomicFMaxEXTForOCL.ll
 new file mode 100644
-index 00000000..1f2530d9
+index 00000000..2a5e947f
 --- /dev/null
 +++ b/test/AtomicFMaxEXTForOCL.ll
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,84 @@
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 +; RUN: spirv-val %t.spv
@@ -825,35 +871,55 @@ index 00000000..1f2530d9
 +define dso_local spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
 +  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_32]]
++  %call = tail call spir_func float @_Z16atomic_fetch_maxPU3AS1VU7_Atomicff(float addrspace(1)* %a, float 0.000000e+00) #2
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_32]]
 +  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_max_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFMaxEXT[[:alnum:]]+fiif]]({{.*}})
-+  %call = tail call spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_32]]
++  %call2 = tail call spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)* %a, float 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func float @_Z16atomic_fetch_maxPU3AS1VU7_Atomicff(float addrspace(1)*, float) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)*, float, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)*, float, i32, i32) local_unnamed_addr #1
++
 +; Function Attrs: convergent norecurse nounwind
 +define dso_local spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
 +  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_64]]
++  %call = tail call spir_func double @_Z16atomic_fetch_maxPU3AS1VU7_Atomicdd(double addrspace(1)* %a, double 0.000000e+00) #2
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_64]]
 +  ; CHECK-LLVM-CL20: call spir_func double @[[DOUBLE_FUNC_NAME:_Z25atomic_fetch_max_explicit[[:alnum:]]+_Atomicdd[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func double @[[DOUBLE_FUNC_NAME:_Z21__spirv_AtomicFMaxEXT[[:alnum:]]+diid]]({{.*}})
-+  %call = tail call spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMaxEXT [[TYPE_FLOAT_64]]
++  %call2 = tail call spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)* %a, double 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func double @_Z16atomic_fetch_maxPU3AS1VU7_Atomicdd(double addrspace(1)*, double) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)*, double, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
++; Function Attrs: convergent
++declare spir_func double @_Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)*, double, i32, i32) local_unnamed_addr #1
++
 +; CHECK-LLVM-CL: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +; CHECK-LLVM-CL: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
-+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
++attributes #0 = { convergent norecurse nounwind "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
 +
 +!llvm.module.flags = !{!0}
@@ -863,7 +929,7 @@ index 00000000..1f2530d9
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 94aa388f0ce0723bb15503cf41c2c15b288375b9)"}
++!2 = !{!"clang version 12.0.1 (https://github.com/llvm/llvm-project.git 23fe7b104a0adaaaecd52108105f49297c420c9b)"}
 diff --git a/test/AtomicFMinEXT.ll b/test/AtomicFMinEXT.ll
 new file mode 100644
 index 00000000..3322836d
@@ -945,10 +1011,10 @@ index 00000000..3322836d
 +
 diff --git a/test/AtomicFMinEXTForOCL.ll b/test/AtomicFMinEXTForOCL.ll
 new file mode 100644
-index 00000000..6196b0f8
+index 00000000..24a9ce5d
 --- /dev/null
 +++ b/test/AtomicFMinEXTForOCL.ll
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,81 @@
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 +; RUN: spirv-val %t.spv
@@ -974,35 +1040,52 @@ index 00000000..6196b0f8
 +define dso_local spir_func void @test_float(float addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
 +  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_32]]
++  %call = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_32]]
 +  ; CHECK-LLVM-CL20: call spir_func float @[[FLOAT_FUNC_NAME:_Z25atomic_fetch_min_explicit[[:alnum:]]+_Atomicff[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func float @[[FLOAT_FUNC_NAME:_Z21__spirv_AtomicFMinEXT[[:alnum:]]+fiif]]({{.*}})
-+  %call = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  %call1 = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)* %a, float 0.000000e+00, i32 0) #2
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_32]]
++  %call2 = tail call spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)* %a, float 0.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
 +
 +; Function Attrs: convergent
 +declare spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order(float addrspace(1)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicff12memory_order12memory_scope(float addrspace(1)*, float, i32, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +
 +; Function Attrs: convergent norecurse nounwind
 +define dso_local spir_func void @test_double(double addrspace(1)* %a) local_unnamed_addr #0 {
 +entry:
++  %call = tail call spir_func double @_Z16atomic_fetch_minPU3AS1VU7_Atomicdd(double addrspace(1)* %a, double 0.000000e+00) #2
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_64]]
++  %call1 = tail call spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
 +  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_64]]
 +  ; CHECK-LLVM-CL20: call spir_func double @[[DOUBLE_FUNC_NAME:_Z25atomic_fetch_min_explicit[[:alnum:]]+_Atomicdd[a-zA-Z0-9_]+]]({{.*}})
 +  ; CHECK-LLVM-SPV: call spir_func double @[[DOUBLE_FUNC_NAME:_Z21__spirv_AtomicFMinEXT[[:alnum:]]+diid]]({{.*}})
-+  %call = tail call spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)* %a, double 0.000000e+00, i32 0) #2
++  %call2 = tail call spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)* %a, double 0.000000e+00, i32 0, i32 1) #2
++  ; CHECK-SPIRV: 7 AtomicFMinEXT [[TYPE_FLOAT_64]]
 +  ret void
 +}
++
++; Function Attrs: convergent
++declare spir_func double @_Z16atomic_fetch_minPU3AS1VU7_Atomicdd(double addrspace(1)*, double) local_unnamed_addr #1
 +
 +; Function Attrs: convergent
 +declare spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order(double addrspace(1)*, double, i32) local_unnamed_addr #1
 +; CHECK-LLVM-SPV: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
++; Function Attrs: convergent
++declare spir_func double @_Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicdd12memory_order12memory_scope(double addrspace(1)*, double, i32, i32) local_unnamed_addr #1
++
 +; CHECK-LLVM-CL: declare {{.*}}spir_func float @[[FLOAT_FUNC_NAME]](float
 +; CHECK-LLVM-CL: declare {{.*}}spir_func double @[[DOUBLE_FUNC_NAME]](double
 +
-+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
-+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
++attributes #0 = { convergent norecurse nounwind "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
++attributes #1 = { convergent "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
 +
 +!llvm.module.flags = !{!0}
@@ -1012,9 +1095,9 @@ index 00000000..6196b0f8
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 94aa388f0ce0723bb15503cf41c2c15b288375b9)"}
++!2 = !{!"clang version 12.0.1 (https://github.com/llvm/llvm-project.git 23fe7b104a0adaaaecd52108105f49297c420c9b)"}
 diff --git a/test/negative/InvalidAtomicBuiltins.cl b/test/negative/InvalidAtomicBuiltins.cl
-index b8ec5b89..bab703b3 100644
+index b8ec5b89..04d71665 100644
 --- a/test/negative/InvalidAtomicBuiltins.cl
 +++ b/test/negative/InvalidAtomicBuiltins.cl
 @@ -1,6 +1,8 @@
@@ -1026,10 +1109,17 @@ index b8ec5b89..bab703b3 100644
  // RUN: %clang_cc1 -triple spir -O1 -cl-std=cl2.0 -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc
  // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
  // RUN: llvm-spirv %t.bc -o %t.spv
-@@ -41,13 +43,9 @@ float __attribute__((overloadable)) atomic_fetch_xor(volatile generic atomic_flo
+@@ -34,20 +36,12 @@ double __attribute__((overloadable)) atom_and(volatile __global double *p, doubl
+ double __attribute__((overloadable)) atom_or(volatile __global double *p, double val);
+ double __attribute__((overloadable)) atom_xor(volatile __global double *p, double val);
+ 
+-float __attribute__((overloadable)) atomic_fetch_add(volatile generic atomic_float *object, float operand, memory_order order);
+-float __attribute__((overloadable)) atomic_fetch_sub(volatile generic atomic_float *object, float operand, memory_order order);
+ float __attribute__((overloadable)) atomic_fetch_or(volatile generic atomic_float *object, float operand, memory_order order);
+ float __attribute__((overloadable)) atomic_fetch_xor(volatile generic atomic_float *object, float operand, memory_order order);
  double __attribute__((overloadable)) atomic_fetch_and(volatile generic atomic_double *object, double operand, memory_order order);
- double __attribute__((overloadable)) atomic_fetch_max(volatile generic atomic_double *object, double operand, memory_order order);
- double __attribute__((overloadable)) atomic_fetch_min(volatile generic atomic_double *object, double operand, memory_order order);
+-double __attribute__((overloadable)) atomic_fetch_max(volatile generic atomic_double *object, double operand, memory_order order);
+-double __attribute__((overloadable)) atomic_fetch_min(volatile generic atomic_double *object, double operand, memory_order order);
 -float __attribute__((overloadable)) atomic_fetch_add_explicit(volatile generic atomic_float *object, float operand, memory_order order);
 -float __attribute__((overloadable)) atomic_fetch_sub_explicit(volatile generic atomic_float *object, float operand, memory_order order);
  float __attribute__((overloadable)) atomic_fetch_or_explicit(volatile generic atomic_float *object, float operand, memory_order order);
@@ -1040,10 +1130,17 @@ index b8ec5b89..bab703b3 100644
  
  __kernel void test_atomic_fn(volatile __global float *p,
                               volatile __global double *pp,
-@@ -86,11 +84,7 @@ __kernel void test_atomic_fn(volatile __global float *p,
+@@ -79,18 +73,10 @@ __kernel void test_atomic_fn(volatile __global float *p,
+     d = atom_or(pp, val);
+     d = atom_xor(pp, val);
+ 
+-    f = atomic_fetch_add(p, val, order);
+-    f = atomic_fetch_sub(p, val, order);
+     f = atomic_fetch_or(p, val, order);
+     f = atomic_fetch_xor(p, val, order);
      d = atomic_fetch_and(pp, val, order);
-     d = atomic_fetch_min(pp, val, order);
-     d = atomic_fetch_max(pp, val, order);
+-    d = atomic_fetch_min(pp, val, order);
+-    d = atomic_fetch_max(pp, val, order);
 -    f = atomic_fetch_add_explicit(p, val, order);
 -    f = atomic_fetch_sub_explicit(p, val, order);
      f = atomic_fetch_or_explicit(p, val, order);


### PR DESCRIPTION
1. Use cl_khr_int64_base_atomics and cl_khr_int64_extended_atomics to guard
the functions using atomic_double type
2. Fix incorrect atomic builtins translation and add related tests

Signed-off-by: haonanya <haonan.yang@intel.com>