### PR TITLE
Update cl_ext_float_atomics patch

### DIFF
--- a/patches/spirv/0002-Add-support-for-cl_ext_float_atomics-in-SPIRVWriter.patch
+++ b/patches/spirv/0002-Add-support-for-cl_ext_float_atomics-in-SPIRVWriter.patch
@@ -1,4 +1,4 @@
-From 719b4b2804af10b15b7134a8fbdbf2687e2640d0 Mon Sep 17 00:00:00 2001
+From dba4306609dc3a9f8b01f6cdeace48b1a8974695 Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
 Date: Wed, 28 Jul 2021 18:27:54 +0800
 Subject: [PATCH] Add support for cl_ext_float_atomics in SPIRVWriter
@@ -6,12 +6,12 @@ Subject: [PATCH] Add support for cl_ext_float_atomics in SPIRVWriter
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
  lib/SPIRV/OCL20ToSPIRV.cpp       |  26 ++++++-
- lib/SPIRV/OCLUtil.cpp            |  20 +++---
+ lib/SPIRV/OCLUtil.cpp            |  16 +++--
  lib/SPIRV/SPIRVToOCL.h           |   3 +
  lib/SPIRV/SPIRVToOCL12.cpp       |  21 ++++++
  lib/SPIRV/SPIRVToOCL20.cpp       |  28 +++++++-
  lib/SPIRV/libSPIRV/SPIRVOpCode.h |   8 ++-
- test/AtomicBuiltinsFloat.ll      |  79 +++++++++++++++++++++
+ test/AtomicBuiltinsFloat.ll      |  94 +++++++++++++++++++++++++
  test/AtomicFAddEXTForOCL.ll      |  88 ++++++++++++++++++++++++
  test/AtomicFAddExt.ll            | 111 +++++++++---------------------
  test/AtomicFMaxEXT.ll            | 113 +++++++++----------------------
@@ -19,7 +19,7 @@ Signed-off-by: haonanya <haonan.yang@intel.com>
  test/AtomicFMinEXT.ll            | 113 +++++++++----------------------
  test/AtomicFMinEXTForOCL.ll      |  81 ++++++++++++++++++++++
  test/InvalidAtomicBuiltins.cl    |  16 -----
- 14 files changed, 518 insertions(+), 273 deletions(-)
+ 14 files changed, 531 insertions(+), 271 deletions(-)
  create mode 100644 test/AtomicBuiltinsFloat.ll
  create mode 100644 test/AtomicFAddEXTForOCL.ll
  create mode 100644 test/AtomicFMaxEXTForOCL.ll
@@ -77,16 +77,16 @@ index a742c8cf..a895307a 100644
        &Attrs);
  }
 diff --git a/lib/SPIRV/OCLUtil.cpp b/lib/SPIRV/OCLUtil.cpp
-index 992f173f..35712ff9 100644
+index 992f173f..f2626c04 100644
 --- a/lib/SPIRV/OCLUtil.cpp
 +++ b/lib/SPIRV/OCLUtil.cpp
 @@ -120,29 +120,31 @@ size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC) {
    return 1;
  }
  
-+// atomic_fetch_[add, sub, min, max] and atomic_fetch_[add, sub, min,
-+// max]_explicit functions are defined on OpenCL headers, they are not
-+// translated to function call
++// atomic_fetch_[add, min, max] and atomic_fetch_[add, min, max]_explicit
++// functions declared in clang headers should be translated to corresponding
++// FP-typed Atomic Instructions
  bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
    if (!DemangledName.startswith(kOCLBuiltinName::AtomicPrefix) &&
        !DemangledName.startswith(kOCLBuiltinName::AtomPrefix))
@@ -94,13 +94,11 @@ index 992f173f..35712ff9 100644
 -
    return llvm::StringSwitch<bool>(DemangledName)
 -      .EndsWith("add", true)
--      .EndsWith("sub", true)
+       .EndsWith("sub", true)
 +      .EndsWith("atomic_add", true)
-+      .EndsWith("atomic_sub", true)
 +      .EndsWith("atomic_min", true)
 +      .EndsWith("atomic_max", true)
 +      .EndsWith("atom_add", true)
-+      .EndsWith("atom_sub", true)
 +      .EndsWith("atom_min", true)
 +      .EndsWith("atom_max", true)
        .EndsWith("inc", true)
@@ -112,7 +110,7 @@ index 992f173f..35712ff9 100644
        .EndsWith("or", true)
        .EndsWith("xor", true)
 -      .EndsWith("add_explicit", true)
--      .EndsWith("sub_explicit", true)
+       .EndsWith("sub_explicit", true)
        .EndsWith("or_explicit", true)
        .EndsWith("xor_explicit", true)
        .EndsWith("and_explicit", true)
@@ -182,7 +180,7 @@ index 1a62c6b8..dc0ba9cc 100644
  }
  
 diff --git a/lib/SPIRV/SPIRVToOCL20.cpp b/lib/SPIRV/SPIRVToOCL20.cpp
-index 24f48956..8147a609 100644
+index 24f48956..c51c9189 100644
 --- a/lib/SPIRV/SPIRVToOCL20.cpp
 +++ b/lib/SPIRV/SPIRVToOCL20.cpp
 @@ -82,6 +82,9 @@ public:
@@ -230,7 +228,7 @@ index 24f48956..8147a609 100644
          }
          auto Ptr = findFirstPtr(Args);
 -        auto Name = OCLSPIRVBuiltinMap::rmap(OC);
-+	std::string Name;
++        std::string Name;
 +        // Map fp atomic instructions to regular OpenCL built-ins.
 +        if (isFPAtomicOpCode(OC))
 +          Name = mapFPAtomicName(OC);
@@ -264,11 +262,13 @@ index feec70f6..8e595e83 100644
    return ((unsigned)OpCode >= OpIAdd && (unsigned)OpCode <= OpFMod) ||
 diff --git a/test/AtomicBuiltinsFloat.ll b/test/AtomicBuiltinsFloat.ll
 new file mode 100644
-index 00000000..53ea871b
+index 00000000..2714f066
 --- /dev/null
 +++ b/test/AtomicBuiltinsFloat.ll
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,94 @@
 +; Check that translator generate atomic instructions for atomic builtins
++; FP-typed atomic_fetch_sub and atomic_fetch_sub_explicit should be translated
++; to FunctionCall
 +; RUN: llvm-as %s -o %t.bc
 +; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 +; RUN: llvm-spirv %t.bc -o %t.spv
@@ -279,12 +279,13 @@ index 00000000..53ea871b
 +; CHECK-COUNT-3: AtomicStore
 +; CHECK-COUNT-3: AtomicLoad
 +; CHECK-COUNT-3: AtomicExchange
++; CHECK-COUNT-3: FunctionCall
 +
 +target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 +target triple = "spir-unknown-unknown"
 +
 +; Function Attrs: convergent nounwind
-+define spir_kernel void @test_atomic_kernel(float addrspace(3)* %ff, float addrspace(3)* nocapture readnone %a) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
++define spir_kernel void @test_atomic_kernel(float addrspace(3)* %ff) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
 +entry:
 +  %0 = addrspacecast float addrspace(3)* %ff to float addrspace(4)*
 +  tail call spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
@@ -297,6 +298,9 @@ index 00000000..53ea871b
 +  %call3 = tail call spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
 +  %call4 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
 +  %call5 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
++  %call6 = tail call spir_func float @_Z16atomic_fetch_subPU3AS3VU7_Atomicff(float addrspace(3)* %ff, float 1.000000e+00) #2
++  %call7 = tail call spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order(float addrspace(3)* %ff, float 1.000000e+00, i32 0) #2
++  %call8 = tail call spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order12memory_scope(float addrspace(3)* %ff, float 1.000000e+00, i32 0, i32 1) #2
 +  ret void
 +}
 +
@@ -330,6 +334,15 @@ index 00000000..53ea871b
 +; Function Attrs: convergent
 +declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
 +
++; Function Attrs: convergent
++declare spir_func float @_Z16atomic_fetch_subPU3AS3VU7_Atomicff(float addrspace(3)*, float) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order(float addrspace(3)*, float, i32) local_unnamed_addr #1
++
++; Function Attrs: convergent
++declare spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order12memory_scope(float addrspace(3)*, float, i32, i32) local_unnamed_addr #1
++
 +attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 +attributes #2 = { convergent nounwind }
@@ -341,12 +354,12 @@ index 00000000..53ea871b
 +
 +!0 = !{i32 1, !"wchar_size", i32 4}
 +!1 = !{i32 2, i32 0}
-+!2 = !{!"clang version 9.0.1 (7e3651de4027cff2d6afda804a914e56dc529487)"}
-+!3 = !{i32 3, i32 3}
-+!4 = !{!"none", !"none"}
-+!5 = !{!"atomic_float*", !"float*"}
-+!6 = !{!"_Atomic(float)*", !"float*"}
-+!7 = !{!"volatile", !""}
++!2 = !{!"clang version 9.0.1 (338587c46f8c87845bd8b98e0338090655bf0313)"}
++!3 = !{i32 3}
++!4 = !{!"none"}
++!5 = !{!"atomic_float*"}
++!6 = !{!"_Atomic(float)*"}
++!7 = !{!"volatile"}
 diff --git a/test/AtomicFAddEXTForOCL.ll b/test/AtomicFAddEXTForOCL.ll
 new file mode 100644
 index 00000000..e8c2ab0b


### PR DESCRIPTION
This fixes incorrect translation for FP-typed atomic_fetch_sub function
and addes tests.

Signed-off-by: haonanya <haonan.yang@intel.com>