### PR TITLE
Exit CMake processing when apply_patches failed

### DIFF
--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -163,7 +163,7 @@ function(apply_patches repo_dir patches_dirs base_revision target_branch ret)
     if (NOT (ret_not_git_repo OR ret_check_out OR ret_apply_patch))
         set(${ret} True PARENT_SCOPE)
     else()
-        message(FATAL_ERROR "apply_patches failed!")
+        message(FATAL_ERROR "[OPENCL-CLANG] Failed to apply patch!")
     endif()
 endfunction()
 

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -149,6 +149,9 @@ function(apply_patches repo_dir patches_dirs base_revision target_branch ret)
                     RESULT_VARIABLE ret_apply_patch
                 )
                 message(STATUS "[OPENCL-CLANG] Not present - ${patching_log}")
+                if (ret_apply_patch)
+                    break()
+                endif()
             endif()
 	    endforeach(patch)
     else() # The target branch already exists

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -146,6 +146,7 @@ function(apply_patches repo_dir patches_dirs base_revision target_branch ret)
                     WORKING_DIRECTORY ${repo_dir}
                     OUTPUT_VARIABLE patching_log
                     ERROR_QUIET
+                    RESULT_VARIABLE ret_apply_patch
                 )
                 message(STATUS "[OPENCL-CLANG] Not present - ${patching_log}")
             endif()
@@ -161,6 +162,8 @@ function(apply_patches repo_dir patches_dirs base_revision target_branch ret)
     endif()
     if (NOT (ret_not_git_repo OR ret_check_out OR ret_apply_patch))
         set(${ret} True PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "apply_patches failed!")
     endif()
 endfunction()
 


### PR DESCRIPTION
When git am operation, which is used to apply patches, fails for some reason during opencl-clang build, the build is continued.
This results in a opencl-clang package without all expected patches applied, it can cause its users to fail.

Signed-off-by: haonanya <haonan.yang@intel.com>