### PR TITLE
Update cl_ext_float_atomics patch

### DIFF
--- a/patches/clang/0005-OpenCL-support-cl_ext_float_atomics.patch
+++ b/patches/clang/0005-OpenCL-support-cl_ext_float_atomics.patch
@@ -1,6 +1,6 @@
-From 389fc0f80da472af9746d3b34e77ad8c7ee2f70e Mon Sep 17 00:00:00 2001
+From 675413e70657ab393a097c70fd7f2b4423d2983b Mon Sep 17 00:00:00 2001
 From: haonanya <haonan.yang@intel.com>
-Date: Fri, 13 Aug 2021 10:00:02 +0800
+Date: Wed, 9 Feb 2022 08:53:06 +0800
 Subject: [PATCH] support cl_ext_float_atomics
 
 This backports https://reviews.llvm.org/D106343 and https://reviews.llvm.org/D109740
@@ -8,10 +8,10 @@ This backports https://reviews.llvm.org/D106343 and https://reviews.llvm.org/D10
 Signed-off-by: haonanya <haonan.yang@intel.com>
 ---
  clang/lib/Headers/opencl-c-base.h     |  22 ++
- clang/lib/Headers/opencl-c.h          | 372 ++++++++++++++++++++++++++
+ clang/lib/Headers/opencl-c.h          | 378 ++++++++++++++++++++++++++
  clang/lib/Sema/Sema.cpp               |   3 +
  clang/test/Headers/opencl-c-header.cl |  96 +++++++
- 4 files changed, 493 insertions(+)
+ 4 files changed, 499 insertions(+)
 
 diff --git a/clang/lib/Headers/opencl-c-base.h b/clang/lib/Headers/opencl-c-base.h
 index 2cc688ccc3da..18d367de68ec 100644
@@ -47,10 +47,10 @@ index 2cc688ccc3da..18d367de68ec 100644
  #ifndef __opencl_c_int64
    #define __opencl_c_int64 1
 diff --git a/clang/lib/Headers/opencl-c.h b/clang/lib/Headers/opencl-c.h
-index d8173f0aa843..be39b1ca8c78 100644
+index d8173f0aa843..efeaea950715 100644
 --- a/clang/lib/Headers/opencl-c.h
 +++ b/clang/lib/Headers/opencl-c.h
-@@ -14354,6 +14354,378 @@ intptr_t __ovld atomic_fetch_max_explicit(
+@@ -14354,6 +14354,384 @@ intptr_t __ovld atomic_fetch_max_explicit(
         // defined(cl_khr_int64_extended_atomics)
  #endif // (__OPENCL_C_VERSION__ >= CL_VERSION_3_0)
  
@@ -220,6 +220,7 @@ index d8173f0aa843..be39b1ca8c78 100644
 +#endif // defined(__opencl_c_ext_fp32_global_atomic_min_max) &&                \
 +    defined(__opencl_c_ext_fp32_local_atomic_min_max)
 +
++#if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
 +#if defined(__opencl_c_ext_fp64_global_atomic_min_max)
 +double __ovld atomic_fetch_min(volatile __global atomic_double *object,
 +                               double operand);
@@ -270,6 +271,8 @@ index d8173f0aa843..be39b1ca8c78 100644
 +                                        memory_scope scope);
 +#endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                \
 +    defined(__opencl_c_ext_fp64_local_atomic_min_max)
++#endif // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
 +#if defined(__opencl_c_ext_fp16_global_atomic_add)
 +half __ovld atomic_fetch_add(volatile __global atomic_half *object,
@@ -373,6 +376,7 @@ index d8173f0aa843..be39b1ca8c78 100644
 +#endif // defined(__opencl_c_ext_fp32_global_atomic_add) &&                    \
 +    defined(__opencl_c_ext_fp32_local_atomic_add)
 +
++#if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
 +#if defined(__opencl_c_ext_fp64_global_atomic_add)
 +double __ovld atomic_fetch_add(volatile __global atomic_double *object,
 +                               double operand);
@@ -423,6 +427,8 @@ index d8173f0aa843..be39b1ca8c78 100644
 +                                        memory_scope scope);
 +#endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&                    \
 +    defined(__opencl_c_ext_fp64_local_atomic_add)
++#endif // defined(cl_khr_int64_base_atomics) &&
++       // defined(cl_khr_int64_extended_atomics)
 +
 +#endif // cl_ext_float_atomics
 +
@@ -548,5 +554,5 @@ index 2716076acdcf..7f720cf28142 100644
 +
 +#endif // defined(__SPIR__)
 -- 
-2.17.1
+2.29.2
 


### PR DESCRIPTION
Guard atomic_double with cl_khr_int64_base_atomics and
cl_khr_int64_extended_atomics.