### PR TITLE
Fix cross build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,26 @@
-project( common_clang )
 cmake_minimum_required(VERSION 3.4.3)
+
+if(NOT DEFINED BASE_LLVM_VERSION)
+  set(BASE_LLVM_VERSION 12.0.0)
+endif(NOT DEFINED BASE_LLVM_VERSION)
+set(OPENCL_CLANG_VERSION ${BASE_LLVM_VERSION}.0)
+
+if(NOT DEFINED OPENCL_CLANG_BUILD_EXTERNAL)
+  # check if we build inside llvm or not
+  if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(OPENCL_CLANG_BUILD_EXTERNAL YES)
+  endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+endif(NOT DEFINED OPENCL_CLANG_BUILD_EXTERNAL)
+
+if(OPENCL_CLANG_BUILD_EXTERNAL)
+  project(OPENCL_CLANG
+    VERSION
+    ${OPENCL_CLANG_VERSION}
+    LANGUAGES
+      CXX
+      C
+  )
+endif()
 
 # Do not omit TARGET_OBJECTS expression from the SOURCES target
 # property
@@ -14,7 +35,7 @@ set(CMAKE_MODULE_PATH
 
 include(CMakeFunctions)
 
-if(LLVM_USE_HOST_TOOLS)
+if(LLVM_USE_HOST_TOOLS AND OPENCL_CLANG_BUILD_EXTERNAL)
   include(CrossCompile)
   llvm_create_cross_target(${PROJECT_NAME} NATIVE "" Release)
 endif()

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To build opencl-clang as a standalone project, you need to obtain pre-built LLVM
 and SPIR-V Translator libraries. **Note:** currently this kind of build is
 supported on Linux only.
 
+If opencl-clang is used as part of another CMake project, you will need to define `OPENCL_CLANG_BUILD_EXTERNAL`.
+
 Integration with pre-built LLVM is done using standard `find_package` way as
 documented in [Embedding LLVM in your project](https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project).
 

--- a/cl_headers/CMakeLists.txt
+++ b/cl_headers/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CL_HEADERS_LIB cl_headers)
 set(CLANG_COMMAND $<TARGET_FILE:clang> )
-if(LLVM_USE_HOST_TOOLS)
+if(LLVM_USE_HOST_TOOLS AND NOT OPENCL_CLANG_BUILD_EXTERNAL)
   build_native_tool(clang CLANG_COMMAND)
 endif()
 


### PR DESCRIPTION
Use llvm_create_cross_target only when opencl-clang is not build inside of llvm.
Call build_native_tool to use self-build clang to build PCH on in-tree build mode.

Signed-off-by: haonanya <haonan.yang@intel.com>