### PR TITLE
Remove out-of-dated hack

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -258,9 +258,6 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       compiler->createFileManager(OverlayFS);
       compiler->createSourceManager(compiler->getFileManager());
 
-      // Calling ResetAllOptionOccurrences as WA for issue from here:
-      // https://reviews.llvm.org/D66324?id=219733#1680231
-      llvm::cl::ResetAllOptionOccurrences();
       // Create compiler invocation from user args before trickering with it
       clang::CompilerInvocation::CreateFromArgs(compiler->getInvocation(),
           optionsParser.args(), *Diags);


### PR DESCRIPTION
Faulty code was fixed in https://github.com/llvm/llvm-project/commit/6d2b75e0887ee87e247756c4d51733616bb2f356

Signed-off-by: Haonan Yang <haonan.yang@intel.com>