### PR TITLE
Noticed missing header when was building llvm with gcc-11

### DIFF
--- a/patches/llvm/0003-Add-missing-include-limit-in-benchmark.patch
+++ b/patches/llvm/0003-Add-missing-include-limit-in-benchmark.patch
@@ -1,0 +1,24 @@
+From 3b6c7f2ea3ff7509769e4567ca242d0e993d425f Mon Sep 17 00:00:00 2001
+From: Marcin Naczk <marcin.naczk@intel.com>
+Date: Tue, 17 May 2022 08:01:41 +0000
+Subject: [PATCH] Add missing include limit in benchmark
+
+---
+ llvm/utils/benchmark/src/benchmark_register.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"
+-- 
+2.34.1
+


### PR DESCRIPTION
Issue fixed on LLVM12, patch needed for older versions of LLVM.
https://reviews.llvm.org/D89450