### PR TITLE
Add shouldPreserveOCLKernelArgTypeMetadataThroughString

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -324,6 +324,7 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       if (!optionsParser.hasOptDisable()) {
         SPIRVOpts.setMemToRegEnabled(true);
       }
+      SPIRVOpts.shouldPreserveOCLKernelArgTypeMetadataThroughString(true);
       success = llvm::writeSpirv(M.get(), SPIRVOpts, OS, Err);
       err_ostream << Err.c_str();
       err_ostream.flush();

--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -324,7 +324,7 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       if (!optionsParser.hasOptDisable()) {
         SPIRVOpts.setMemToRegEnabled(true);
       }
-      SPIRVOpts.shouldPreserveOCLKernelArgTypeMetadataThroughString(true);
+      SPIRVOpts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
       success = llvm::writeSpirv(M.get(), SPIRVOpts, OS, Err);
       err_ostream << Err.c_str();
       err_ostream.flush();


### PR DESCRIPTION
Because of commit:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/835eb7e8696ab4ba764d6e1b4c2f3e2c4ddc0551
Need to add shouldPreserveOCLKernelArgTypeMetadataThroughString
to SPIRV::TranslatorOpts to still be able to correctly parse
kernel arguments type, by metadata.