### PR TITLE
Update SPIRV branch from master to main

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: KhronosGroup/SPIRV-LLVM-Translator
-          ref: master
+          ref: main
           path: llvm-project/SPIRV-LLVM-Translator
       - name:  Checkout opencl-clang sources
         uses: actions/checkout@v2


### PR DESCRIPTION
The default branch is main for SPRIV currently.

Signed-off-by: haonanya <haonan.yang@intel.com>