### PR TITLE
Add patch for opencl-c.h which adds missing __opencl_c_images macros

### DIFF
--- a/patches/clang/0002-Fix-missing-__opencl_c_images-macro-in-opencl-c.h.patch
+++ b/patches/clang/0002-Fix-missing-__opencl_c_images-macro-in-opencl-c.h.patch
@@ -1,0 +1,486 @@
+From 96369f57d8af6821b1d784e3da5449e632407b7d Mon Sep 17 00:00:00 2001
+From: Marcin Naczk <marcin.naczk@intel.com>
+Date: Mon, 3 Oct 2022 11:40:39 +0200
+Subject: [PATCH] Fix missing __opencl_c_images macro in opencl-c.h
+
+Local fix for Clang issue https://github.com/llvm/llvm-project/issues/58017
+---
+ clang/lib/Headers/opencl-c.h | 78 +++++++++++++++++++++++++++++++-----
+ 1 file changed, 67 insertions(+), 11 deletions(-)
+
+diff --git a/clang/lib/Headers/opencl-c.h b/clang/lib/Headers/opencl-c.h
+index c7bb77716ac4..f3bb2a504e7b 100644
+--- a/clang/lib/Headers/opencl-c.h
++++ b/clang/lib/Headers/opencl-c.h
+@@ -15432,7 +15432,7 @@ half16 __ovld __cnfn shuffle2(half16 x, half16 y, ushort16 mask);
+  * with image_channel_data_type values not specified
+  * in the description above are undefined.
+  */
+-
++#if defined(__opencl_c_images)
+ float4 __purefn __ovld read_imagef(read_only image2d_t image, sampler_t sampler, int2 coord);
+ float4 __purefn __ovld read_imagef(read_only image2d_t image, sampler_t sampler, float2 coord);
+ 
+@@ -15476,6 +15476,7 @@ int4 __purefn __ovld read_imagei(read_only image1d_array_t image_array, sampler_
+ uint4 __purefn __ovld read_imageui(read_only image1d_array_t image_array, sampler_t sampler, int2 coord);
+ uint4 __purefn __ovld read_imageui(read_only image1d_array_t image_array, sampler_t sampler, float2 coord);
+ #endif // defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_1_2)
++#endif // defined(__opencl_c_images)
+ 
+ #ifdef cl_khr_depth_images
+ float __purefn __ovld read_imagef(read_only image2d_depth_t image, sampler_t sampler, float2 coord);
+@@ -15554,12 +15555,11 @@ uint4 __purefn __ovld read_imageui(read_only image3d_t image, sampler_t sampler,
+ #endif //cl_khr_mipmap_image
+ #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
+ 
++#if defined(__opencl_c_images)
+ #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_1_2)
+-
+ /**
+ * Sampler-less Image Access
+ */
+-
+ float4 __purefn __ovld read_imagef(read_only image1d_t image, int coord);
+ int4 __purefn __ovld read_imagei(read_only image1d_t image, int coord);
+ uint4 __purefn __ovld read_imageui(read_only image1d_t image, int coord);
+@@ -15721,6 +15721,7 @@ half4 __purefn __ovld read_imageh(read_write image2d_array_t image, int4 coord);
+ half4 __purefn __ovld read_imageh(read_write image1d_buffer_t image, int coord);
+ #endif //cl_khr_fp16
+ #endif //defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ /**
+  * Write color value to location specified by coordinate
+@@ -15789,6 +15790,7 @@ half4 __purefn __ovld read_imageh(read_write image1d_buffer_t image, int coord);
+  * values that are not in the range (0 ... image width -1,
+  * 0 ... image height - 1), respectively, is undefined.
+  */
++#if defined(__opencl_c_images)
+ void __ovld write_imagef(write_only image2d_t image, int2 coord, float4 color);
+ void __ovld write_imagei(write_only image2d_t image, int2 coord, int4 color);
+ void __ovld write_imageui(write_only image2d_t image, int2 coord, uint4 color);
+@@ -15808,6 +15810,7 @@ void __ovld write_imageui(write_only image1d_buffer_t image, int coord, uint4 co
+ void __ovld write_imagef(write_only image1d_array_t image_array, int2 coord, float4 color);
+ void __ovld write_imagei(write_only image1d_array_t image_array, int2 coord, int4 color);
+ void __ovld write_imageui(write_only image1d_array_t image_array, int2 coord, uint4 color);
++#endif // defined(__opencl_c_images)
+ 
+ #ifdef cl_khr_3d_image_writes
+ void __ovld write_imagef(write_only image3d_t image, int4 coord, float4 color);
+@@ -15852,6 +15855,7 @@ void __ovld write_imageui(write_only image3d_t image, int4 coord, int lod, uint4
+ #endif //defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
+ 
+ // Image write functions for half4 type
++#if defined(__opencl_c_images)
+ #ifdef cl_khr_fp16
+ void __ovld write_imageh(write_only image1d_t image, int coord, half4 color);
+ void __ovld write_imageh(write_only image2d_t image, int2 coord, half4 color);
+@@ -15936,6 +15940,7 @@ void __ovld write_imageh(read_write image2d_array_t image, int4 coord, half4 col
+ void __ovld write_imageh(read_write image1d_buffer_t image, int coord, half4 color);
+ #endif //cl_khr_fp16
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ // Note: In OpenCL v1.0/1.1/1.2, image argument of image query builtin functions does not have
+ // access qualifier, which by default assume read_only access qualifier. Image query builtin
+@@ -15945,14 +15950,18 @@ void __ovld write_imageh(read_write image1d_buffer_t image, int coord, half4 col
+  * Return the image width in pixels.
+  *
+   */
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_width(read_only image1d_t image);
+ int __ovld __cnfn get_image_width(read_only image1d_buffer_t image);
+ int __ovld __cnfn get_image_width(read_only image2d_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_3d_image_writes
+ int __ovld __cnfn get_image_width(read_only image3d_t image);
+ #endif
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_width(read_only image1d_array_t image);
+ int __ovld __cnfn get_image_width(read_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_width(read_only image2d_depth_t image);
+ int __ovld __cnfn get_image_width(read_only image2d_array_depth_t image);
+@@ -15964,14 +15973,19 @@ int __ovld __cnfn get_image_width(read_only image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_width(read_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_width(write_only image1d_t image);
+ int __ovld __cnfn get_image_width(write_only image1d_buffer_t image);
+ int __ovld __cnfn get_image_width(write_only image2d_t image);
++#endif //defined(__opencl_c_images)
++
+ #ifdef cl_khr_3d_image_writes
+ int __ovld __cnfn get_image_width(write_only image3d_t image);
+ #endif
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_width(write_only image1d_array_t image);
+ int __ovld __cnfn get_image_width(write_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_width(write_only image2d_depth_t image);
+ int __ovld __cnfn get_image_width(write_only image2d_array_depth_t image);
+@@ -15983,6 +15997,7 @@ int __ovld __cnfn get_image_width(write_only image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_width(write_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ int __ovld __cnfn get_image_width(read_write image1d_t image);
+ int __ovld __cnfn get_image_width(read_write image1d_buffer_t image);
+@@ -16001,13 +16016,17 @@ int __ovld __cnfn get_image_width(read_write image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_width(read_write image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+  * Return the image height in pixels.
+  */
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_height(read_only image2d_t image);
+ int __ovld __cnfn get_image_height(read_only image3d_t image);
+ int __ovld __cnfn get_image_height(read_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
++
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_height(read_only image2d_depth_t image);
+ int __ovld __cnfn get_image_height(read_only image2d_array_depth_t image);
+@@ -16019,11 +16038,14 @@ int __ovld __cnfn get_image_height(read_only image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_height(read_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_height(write_only image2d_t image);
+ #ifdef cl_khr_3d_image_writes
+ int __ovld __cnfn get_image_height(write_only image3d_t image);
+ #endif
+ int __ovld __cnfn get_image_height(write_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
++
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_height(write_only image2d_depth_t image);
+ int __ovld __cnfn get_image_height(write_only image2d_array_depth_t image);
+@@ -16035,6 +16057,7 @@ int __ovld __cnfn get_image_height(write_only image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_height(write_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ int __ovld __cnfn get_image_height(read_write image2d_t image);
+ int __ovld __cnfn get_image_height(read_write image3d_t image);
+@@ -16050,19 +16073,24 @@ int __ovld __cnfn get_image_height(read_write image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_height(read_write image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+  * Return the image depth in pixels.
+  */
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_depth(read_only image3d_t image);
++#endif //defined(__opencl_c_images)
+ 
+ #ifdef cl_khr_3d_image_writes
+ int __ovld __cnfn get_image_depth(write_only image3d_t image);
+ #endif
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ int __ovld __cnfn get_image_depth(read_write image3d_t image);
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ // OpenCL Extension v2.0 s9.18 - Mipmaps
+ #if defined(__OPENCL_CPP_VERSION__) || (__OPENCL_C_VERSION__ >= CL_VERSION_2_0)
+@@ -16126,12 +16154,14 @@ int __ovld get_image_num_mip_levels(read_write image2d_depth_t image);
+  * CLK_FLOAT
+  */
+ 
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_channel_data_type(read_only image1d_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_only image1d_buffer_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_only image2d_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_only image3d_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_only image1d_array_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_channel_data_type(read_only image2d_depth_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_only image2d_array_depth_t image);
+@@ -16143,14 +16173,19 @@ int __ovld __cnfn get_image_channel_data_type(read_only image2d_array_msaa_t ima
+ int __ovld __cnfn get_image_channel_data_type(read_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_channel_data_type(write_only image1d_t image);
+ int __ovld __cnfn get_image_channel_data_type(write_only image1d_buffer_t image);
+ int __ovld __cnfn get_image_channel_data_type(write_only image2d_t image);
++#endif //defined(__opencl_c_images)
++
+ #ifdef cl_khr_3d_image_writes
+ int __ovld __cnfn get_image_channel_data_type(write_only image3d_t image);
+ #endif
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_channel_data_type(write_only image1d_array_t image);
+ int __ovld __cnfn get_image_channel_data_type(write_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_channel_data_type(write_only image2d_depth_t image);
+ int __ovld __cnfn get_image_channel_data_type(write_only image2d_array_depth_t image);
+@@ -16162,6 +16197,7 @@ int __ovld __cnfn get_image_channel_data_type(write_only image2d_array_msaa_t im
+ int __ovld __cnfn get_image_channel_data_type(write_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ int __ovld __cnfn get_image_channel_data_type(read_write image1d_t image);
+ int __ovld __cnfn get_image_channel_data_type(read_write image1d_buffer_t image);
+@@ -16180,6 +16216,7 @@ int __ovld __cnfn get_image_channel_data_type(read_write image2d_array_msaa_t im
+ int __ovld __cnfn get_image_channel_data_type(read_write image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+  * Return the image channel order. Valid values are:
+@@ -16197,13 +16234,15 @@ int __ovld __cnfn get_image_channel_data_type(read_write image2d_array_msaa_dept
+  * CLK_INTENSITY
+  * CLK_LUMINANCE
+  */
+-
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_channel_order(read_only image1d_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image1d_buffer_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image2d_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image3d_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image1d_array_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
++
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_channel_order(read_only image2d_depth_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image2d_array_depth_t image);
+@@ -16215,6 +16254,7 @@ int __ovld __cnfn get_image_channel_order(read_only image2d_array_msaa_t image);
+ int __ovld __cnfn get_image_channel_order(read_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ int __ovld __cnfn get_image_channel_order(write_only image1d_t image);
+ int __ovld __cnfn get_image_channel_order(write_only image1d_buffer_t image);
+ int __ovld __cnfn get_image_channel_order(write_only image2d_t image);
+@@ -16223,6 +16263,7 @@ int __ovld __cnfn get_image_channel_order(write_only image3d_t image);
+ #endif
+ int __ovld __cnfn get_image_channel_order(write_only image1d_array_t image);
+ int __ovld __cnfn get_image_channel_order(write_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int __ovld __cnfn get_image_channel_order(write_only image2d_depth_t image);
+ int __ovld __cnfn get_image_channel_order(write_only image2d_array_depth_t image);
+@@ -16234,6 +16275,7 @@ int __ovld __cnfn get_image_channel_order(write_only image2d_array_msaa_t image)
+ int __ovld __cnfn get_image_channel_order(write_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ int __ovld __cnfn get_image_channel_order(read_write image1d_t image);
+ int __ovld __cnfn get_image_channel_order(read_write image1d_buffer_t image);
+@@ -16252,14 +16294,17 @@ int __ovld __cnfn get_image_channel_order(read_write image2d_array_msaa_t image)
+ int __ovld __cnfn get_image_channel_order(read_write image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+  * Return the 2D image width and height as an int2
+  * type. The width is returned in the x component, and
+  * the height in the y component.
+  */
++#if defined(__opencl_c_images)
+ int2 __ovld __cnfn get_image_dim(read_only image2d_t image);
+ int2 __ovld __cnfn get_image_dim(read_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int2 __ovld __cnfn get_image_dim(read_only image2d_array_depth_t image);
+ int2 __ovld __cnfn get_image_dim(read_only image2d_depth_t image);
+@@ -16271,8 +16316,10 @@ int2 __ovld __cnfn get_image_dim(read_only image2d_array_msaa_t image);
+ int2 __ovld __cnfn get_image_dim(read_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ int2 __ovld __cnfn get_image_dim(write_only image2d_t image);
+ int2 __ovld __cnfn get_image_dim(write_only image2d_array_t image);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ int2 __ovld __cnfn get_image_dim(write_only image2d_array_depth_t image);
+ int2 __ovld __cnfn get_image_dim(write_only image2d_depth_t image);
+@@ -16284,6 +16331,7 @@ int2 __ovld __cnfn get_image_dim(write_only image2d_array_msaa_t image);
+ int2 __ovld __cnfn get_image_dim(write_only image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ int2 __ovld __cnfn get_image_dim(read_write image2d_t image);
+ int2 __ovld __cnfn get_image_dim(read_write image2d_array_t image);
+@@ -16298,6 +16346,7 @@ int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_t image);
+ int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_depth_t image);
+ #endif //cl_khr_gl_msaa_sharing
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+  * Return the 3D image width, height, and depth as an
+@@ -16305,6 +16354,7 @@ int2 __ovld __cnfn get_image_dim(read_write image2d_array_msaa_depth_t image);
+  * component, height in the y component, depth in the z
+  * component and the w component is 0.
+  */
++#if defined(__opencl_c_images)
+ int4 __ovld __cnfn get_image_dim(read_only image3d_t image);
+ #ifdef cl_khr_3d_image_writes
+ int4 __ovld __cnfn get_image_dim(write_only image3d_t image);
+@@ -16312,13 +16362,15 @@ int4 __ovld __cnfn get_image_dim(write_only image3d_t image);
+ #if defined(__opencl_c_read_write_images)
+ int4 __ovld __cnfn get_image_dim(read_write image3d_t image);
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+  * Return the image array size.
+  */
+-
++#if defined(__opencl_c_images)
+ size_t __ovld __cnfn get_image_array_size(read_only image1d_array_t image_array);
+ size_t __ovld __cnfn get_image_array_size(read_only image2d_array_t image_array);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ size_t __ovld __cnfn get_image_array_size(read_only image2d_array_depth_t image_array);
+ #endif //cl_khr_depth_images
+@@ -16327,8 +16379,10 @@ size_t __ovld __cnfn get_image_array_size(read_only image2d_array_msaa_t image_a
+ size_t __ovld __cnfn get_image_array_size(read_only image2d_array_msaa_depth_t image_array);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ size_t __ovld __cnfn get_image_array_size(write_only image1d_array_t image_array);
+ size_t __ovld __cnfn get_image_array_size(write_only image2d_array_t image_array);
++#endif //defined(__opencl_c_images)
+ #ifdef cl_khr_depth_images
+ size_t __ovld __cnfn get_image_array_size(write_only image2d_array_depth_t image_array);
+ #endif //cl_khr_depth_images
+@@ -16337,6 +16391,7 @@ size_t __ovld __cnfn get_image_array_size(write_only image2d_array_msaa_t image_
+ size_t __ovld __cnfn get_image_array_size(write_only image2d_array_msaa_depth_t image_array);
+ #endif //cl_khr_gl_msaa_sharing
+ 
++#if defined(__opencl_c_images)
+ #if defined(__opencl_c_read_write_images)
+ size_t __ovld __cnfn get_image_array_size(read_write image1d_array_t image_array);
+ size_t __ovld __cnfn get_image_array_size(read_write image2d_array_t image_array);
+@@ -16348,6 +16403,7 @@ size_t __ovld __cnfn get_image_array_size(read_write image2d_array_msaa_t image_
+ size_t __ovld __cnfn get_image_array_size(read_write image2d_array_msaa_depth_t image_array);
+ #endif //cl_khr_gl_msaa_sharing
+ #endif //defined(__opencl_c_read_write_images)
++#endif //defined(__opencl_c_images)
+ 
+ /**
+ * Return the number of samples associated with image
+@@ -17611,7 +17667,6 @@ uint    __ovld __conv intel_sub_group_block_read( read_only image2d_t image, int
+ uint2   __ovld __conv intel_sub_group_block_read2( read_only image2d_t image, int2 coord );
+ uint4   __ovld __conv intel_sub_group_block_read4( read_only image2d_t image, int2 coord );
+ uint8   __ovld __conv intel_sub_group_block_read8( read_only image2d_t image, int2 coord );
+-#endif
+ 
+ #if defined(__opencl_c_read_write_images)
+ uint    __ovld __conv intel_sub_group_block_read(read_write image2d_t image, int2 coord);
+@@ -17619,6 +17674,7 @@ uint2   __ovld __conv intel_sub_group_block_read2(read_write image2d_t image, in
+ uint4   __ovld __conv intel_sub_group_block_read4(read_write image2d_t image, int2 coord);
+ uint8   __ovld __conv intel_sub_group_block_read8(read_write image2d_t image, int2 coord);
+ #endif // defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ uint    __ovld __conv intel_sub_group_block_read( const __global uint* p );
+ uint2   __ovld __conv intel_sub_group_block_read2( const __global uint* p );
+@@ -17630,7 +17686,6 @@ void    __ovld __conv intel_sub_group_block_write(write_only image2d_t image, in
+ void    __ovld __conv intel_sub_group_block_write2(write_only image2d_t image, int2 coord, uint2 data);
+ void    __ovld __conv intel_sub_group_block_write4(write_only image2d_t image, int2 coord, uint4 data);
+ void    __ovld __conv intel_sub_group_block_write8(write_only image2d_t image, int2 coord, uint8 data);
+-#endif // defined(__opencl_c_images)
+ 
+ #if defined(__opencl_c_read_write_images)
+ void    __ovld __conv intel_sub_group_block_write(read_write image2d_t image, int2 coord, uint data);
+@@ -17638,6 +17693,7 @@ void    __ovld __conv intel_sub_group_block_write2(read_write image2d_t image, i
+ void    __ovld __conv intel_sub_group_block_write4(read_write image2d_t image, int2 coord, uint4 data);
+ void    __ovld __conv intel_sub_group_block_write8(read_write image2d_t image, int2 coord, uint8 data);
+ #endif // defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ void    __ovld __conv intel_sub_group_block_write( __global uint* p, uint data );
+ void    __ovld __conv intel_sub_group_block_write2( __global uint* p, uint2 data );
+@@ -17755,7 +17811,6 @@ uint       __ovld __conv intel_sub_group_block_read_ui( read_only image2d_t imag
+ uint2      __ovld __conv intel_sub_group_block_read_ui2( read_only image2d_t image, int2 byte_coord );
+ uint4      __ovld __conv intel_sub_group_block_read_ui4( read_only image2d_t image, int2 byte_coord );
+ uint8      __ovld __conv intel_sub_group_block_read_ui8( read_only image2d_t image, int2 byte_coord );
+-#endif // defined(__opencl_c_images)
+ 
+ #if defined(__opencl_c_read_write_images)
+ uint       __ovld __conv intel_sub_group_block_read_ui( read_write image2d_t image, int2 byte_coord );
+@@ -17763,6 +17818,7 @@ uint2      __ovld __conv intel_sub_group_block_read_ui2( read_write image2d_t im
+ uint4      __ovld __conv intel_sub_group_block_read_ui4( read_write image2d_t image, int2 byte_coord );
+ uint8      __ovld __conv intel_sub_group_block_read_ui8( read_write image2d_t image, int2 byte_coord );
+ #endif // defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ uint       __ovld __conv intel_sub_group_block_read_ui( const __global uint* p );
+ uint2      __ovld __conv intel_sub_group_block_read_ui2( const __global uint* p );
+@@ -17774,7 +17830,6 @@ void       __ovld __conv intel_sub_group_block_write_ui( read_only image2d_t ima
+ void       __ovld __conv intel_sub_group_block_write_ui2( read_only image2d_t image, int2 byte_coord, uint2 data );
+ void       __ovld __conv intel_sub_group_block_write_ui4( read_only image2d_t image, int2 byte_coord, uint4 data );
+ void       __ovld __conv intel_sub_group_block_write_ui8( read_only image2d_t image, int2 byte_coord, uint8 data );
+-#endif //defined(__opencl_c_images)
+ 
+ #if defined(__opencl_c_read_write_images)
+ void       __ovld __conv intel_sub_group_block_write_ui( read_write image2d_t image, int2 byte_coord, uint data );
+@@ -17782,6 +17837,7 @@ void       __ovld __conv intel_sub_group_block_write_ui2( read_write image2d_t i
+ void       __ovld __conv intel_sub_group_block_write_ui4( read_write image2d_t image, int2 byte_coord, uint4 data );
+ void       __ovld __conv intel_sub_group_block_write_ui8( read_write image2d_t image, int2 byte_coord, uint8 data );
+ #endif // defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ void       __ovld __conv intel_sub_group_block_write_ui( __global uint* p, uint data );
+ void       __ovld __conv intel_sub_group_block_write_ui2( __global uint* p, uint2 data );
+@@ -17793,7 +17849,6 @@ ushort      __ovld __conv intel_sub_group_block_read_us( read_only image2d_t ima
+ ushort2     __ovld __conv intel_sub_group_block_read_us2( read_only image2d_t image, int2 coord );
+ ushort4     __ovld __conv intel_sub_group_block_read_us4( read_only image2d_t image, int2 coord );
+ ushort8     __ovld __conv intel_sub_group_block_read_us8( read_only image2d_t image, int2 coord );
+-#endif // defined(__opencl_c_images)
+ 
+ #if defined(__opencl_c_read_write_images)
+ ushort      __ovld __conv intel_sub_group_block_read_us(read_write image2d_t image, int2 coord);
+@@ -17801,6 +17856,7 @@ ushort2     __ovld __conv intel_sub_group_block_read_us2(read_write image2d_t im
+ ushort4     __ovld __conv intel_sub_group_block_read_us4(read_write image2d_t image, int2 coord);
+ ushort8     __ovld __conv intel_sub_group_block_read_us8(read_write image2d_t image, int2 coord);
+ #endif // defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ ushort      __ovld __conv intel_sub_group_block_read_us(  const __global ushort* p );
+ ushort2     __ovld __conv intel_sub_group_block_read_us2( const __global ushort* p );
+@@ -17812,7 +17868,6 @@ void        __ovld __conv intel_sub_group_block_write_us(write_only image2d_t im
+ void        __ovld __conv intel_sub_group_block_write_us2(write_only image2d_t image, int2 coord, ushort2 data);
+ void        __ovld __conv intel_sub_group_block_write_us4(write_only image2d_t image, int2 coord, ushort4 data);
+ void        __ovld __conv intel_sub_group_block_write_us8(write_only image2d_t image, int2 coord, ushort8 data);
+-#endif // defined(__opencl_c_images)
+ 
+ #if defined(__opencl_c_read_write_images)
+ void        __ovld __conv intel_sub_group_block_write_us(read_write image2d_t image, int2 coord, ushort  data);
+@@ -17820,6 +17875,7 @@ void        __ovld __conv intel_sub_group_block_write_us2(read_write image2d_t i
+ void        __ovld __conv intel_sub_group_block_write_us4(read_write image2d_t image, int2 coord, ushort4 data);
+ void        __ovld __conv intel_sub_group_block_write_us8(read_write image2d_t image, int2 coord, ushort8 data);
+ #endif // defined(__opencl_c_read_write_images)
++#endif // defined(__opencl_c_images)
+ 
+ void        __ovld __conv intel_sub_group_block_write_us(  __global ushort* p, ushort  data );
+ void        __ovld __conv intel_sub_group_block_write_us2( __global ushort* p, ushort2 data );
+-- 
+2.25.1
+


### PR DESCRIPTION
This fixes the issue https://github.com/llvm/llvm-project/issues/58017 for clang-14