### PR TITLE
Lower -profiling option to -debug-info-kind=line-tables-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13.4)
 
 if(NOT DEFINED BASE_LLVM_VERSION)
   set(BASE_LLVM_VERSION 16.0.0)
@@ -83,6 +83,8 @@ include(TableGen)
 if (NOT WIN32)
     add_subdirectory( linux_linker bin)
 endif()
+
+use_rtti(FALSE)
 
 if (CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(ADDR 32)

--- a/cl_headers/CMakeLists.txt
+++ b/cl_headers/CMakeLists.txt
@@ -101,7 +101,7 @@ add_custom_target (
 function(pack_to_obj SRC DST TAG)
     add_custom_command (
         OUTPUT ${DST}
-        DEPENDS ${SRC} linux_resource_linker
+        DEPENDS ${SRC} ${LINUX_RESOURCE_LINKER_COMMAND}
         COMMAND ${LINUX_RESOURCE_LINKER_COMMAND} "${SRC}" "${DST}" "${TAG}"
         COMMENT "Packing ${SRC}"
     )

--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -40,7 +40,6 @@ Copyright (c) Intel Corporation (2009-2017).
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Mutex.h"
-#include "llvm/Support/VirtualFileSystem.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticIDs.h"
@@ -63,11 +62,8 @@ Copyright (c) Intel Corporation (2009-2017).
 #define CL_OUT_OF_HOST_MEMORY -6
 
 #include "assert.h"
-#include <algorithm>
 #include <iosfwd>
 #include <iterator>
-#include <list>
-#include <streambuf>
 #ifdef _WIN32
 #include <ctype.h>
 #endif
@@ -265,8 +261,6 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       ProcessWarningOptions(*Diags, compiler->getDiagnosticOpts());
 
       // Map memory buffers to a virtual file system
-
-      // Source file
       MemFS->addFile(
           optionsParser.getSourceName(), (time_t)0,
           llvm::MemoryBuffer::getMemBuffer(

--- a/options.h
+++ b/options.h
@@ -71,6 +71,8 @@ public:
 
   const char *MakeArgStringRef(llvm::StringRef str) const override;
 
+  virtual ~OpenCLArgList() {}
+
 private:
   /// List of argument strings used by the contained Args.
   ///
@@ -93,10 +95,10 @@ private:
 //
 // OpenCL specific OptTable
 //
-class OpenCLOptTable : public llvm::opt::OptTable {
+class OpenCLOptTable : public llvm::opt::GenericOptTable {
 public:
   OpenCLOptTable(llvm::ArrayRef<Info> pOptionInfos)
-      : OptTable(pOptionInfos) {}
+      : llvm::opt::GenericOptTable(pOptionInfos) {}
 
   OpenCLArgList *ParseArgs(const char *szOptions, unsigned &missingArgIndex,
                            unsigned &missingArgCount) const;

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -165,6 +165,10 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
     case OPT_COMPILE_g_Flag:
       effectiveArgs.push_back("-debug-info-kind=limited");
       effectiveArgs.push_back("-dwarf-version=4");
+#ifdef _WIN32
+      // Do not use column information on Windows.
+      effectiveArgs.push_back("-gno-column-info");
+#endif
       break;
     }
   }

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -29,7 +29,8 @@ Copyright (c) Intel Corporation (2009-2017).
 #include <map>
 #include <sstream>
 
-#define PREFIX(NAME, VALUE) const char *const NAME[] = VALUE;
+#define PREFIX(NAME, VALUE)                                                    \
+  const llvm::ArrayRef<llvm::StringLiteral> NAME = VALUE;
 #define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
                HELPTEXT, METAVAR, VALUES)
 #include "opencl_clang_options.inc"
@@ -47,7 +48,7 @@ static const OptTable::Info ClangOptionsInfoTable[] = {
   {                                                                            \
     PREFIX, NAME, HELPTEXT, METAVAR, OPT_COMPILE_##ID,                         \
         llvm::opt::Option::KIND##Class, PARAM, FLAGS, OPT_COMPILE_##GROUP,     \
-        OPT_COMPILE_##ALIAS, ALIASARGS                                         \
+        OPT_COMPILE_##ALIAS, ALIASARGS, VALUES                                 \
   }                                                                            \
   ,
 #include "opencl_clang_options.inc"
@@ -157,12 +158,12 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
       // default:
       // assert(false && "some unknown argument");
     case OPT_COMPILE_profiling:
-    case OPT_COMPILE_g_Flag:
-      effectiveArgs.push_back("-debug-info-kind=limited");
-      effectiveArgs.push_back("-dwarf-version=4");
-      break;
     case OPT_COMPILE_gline_tables_only_Flag:
       effectiveArgs.push_back("-debug-info-kind=line-tables-only");
+      effectiveArgs.push_back("-dwarf-version=4");
+      break;
+    case OPT_COMPILE_g_Flag:
+      effectiveArgs.push_back("-debug-info-kind=limited");
       effectiveArgs.push_back("-dwarf-version=4");
       break;
     }
@@ -220,7 +221,7 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
   // OpenCL v2.0 s6.9.u - Implicit function declaration is not supported.
   // Behavior of clang is changed and now there is only warning about
   // implicit function declarations. To be more user friendly and avoid
-  // unexpected indirect function calls in IR, let's force this warning to
+  // unexpected indirect function calls in BE, let's force this warning to
   // error.
   effectiveArgs.push_back("-Werror=implicit-function-declaration");
 

--- a/pch_mgr.cpp
+++ b/pch_mgr.cpp
@@ -18,8 +18,8 @@ Copyright (c) Intel Corporation (2009-2017).
 
 #include "pch_mgr.h"
 
-#include "llvm/Object/ELF.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Object/ELF.h"
 
 #include <cstdlib>
 #include <stdio.h>
@@ -35,6 +35,8 @@ struct auto_dlclose {
   auto_dlclose(void *module) : m_pModule(module) {}
 
   ~auto_dlclose() {
+    if (m_pModule)
+      dlclose(m_pModule);
   }
 
   void *get() { return m_pModule; }


### PR DESCRIPTION
'-profiling' option aims source code view under VTune. Turning it on means that debug information will be generated and all optimizations will be made. Most of OpenCL transformation passes (vectorizer, barrier, etc.) work with debug information too offhandedly. To minimize risks to get debug information broken, let's generate it as less as possible.

The patch also does other several things:
1. Update minimum cmake version to 3.13.4 to align with LLVM's cmake requirement.
2. Remove unused header and format code
3. Fix some build warnings