### PR TITLE
README.md: fix cmake error "No build type selected"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cmake -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_ENABLE_PROJECTS="clang" \
       -DLLVM_EXTERNAL_PROJECTS="llvm-spirv;opencl-clang" \
       -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR="$OCL_CLANG_WS/SPIRV-LLVM-Translator" \
       -DLLVM_EXTERNAL_OPENCL_CLANG_SOURCE_DIR="$OCL_CLANG_WS/opencl-clang" \
-      $OCL_CLANG_WS/llvm
+      -DCMAKE_BUILD_TYPE=Release $OCL_CLANG_WS/llvm
 make opencl-clang -j`nproc`
 ```
 


### PR DESCRIPTION
Fix following error:
```
CMake Error at CMakeLists.txt:97 (message):


  No build type selected.  You need to pass -DCMAKE_BUILD_TYPE=<type> in
  order to configure LLVM.

  Available options are:

    * -DCMAKE_BUILD_TYPE=Release - For an optimized build with no assertions or debug info.
    * -DCMAKE_BUILD_TYPE=Debug - For an unoptimized build with assertions and debug info.
    * -DCMAKE_BUILD_TYPE=RelWithDebInfo - For an optimized build with no assertions but with debug info.
    * -DCMAKE_BUILD_TYPE=MinSizeRel - For a build optimized for size instead of speed.

  Learn more about these options in our documentation at
  https://llvm.org/docs/CMake.html#cmake-build-type



-- Configuring incomplete, errors occurred!
```