### PR TITLE
Erase image support macros' definition from `opencl-c-base.h`

### DIFF
--- a/patches/clang/0004-Do-not-define-image-support-macros-in-OpenCL-C-base.patch
+++ b/patches/clang/0004-Do-not-define-image-support-macros-in-OpenCL-C-base.patch
@@ -1,0 +1,35 @@
+From 1e987989037c52c0c786f7c9b6b5bed21b740375 Mon Sep 17 00:00:00 2001
+From: Artem Gindinson <artem.gindinson@intel.com>
+Date: Thu, 23 Mar 2023 10:58:45 +0100
+Subject: [PATCH] [PATCH] Do not define image support macros in OpenCL C header
+ base
+
+---
+ clang/lib/Headers/opencl-c-base.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/clang/lib/Headers/opencl-c-base.h b/clang/lib/Headers/opencl-c-base.h
+index 5191c41bcd05..8907886aeecf 100644
+--- a/clang/lib/Headers/opencl-c-base.h
++++ b/clang/lib/Headers/opencl-c-base.h
+@@ -58,9 +58,7 @@
+ #define __opencl_c_atomic_scope_device 1
+ #define __opencl_c_atomic_scope_all_devices 1
+ #define __opencl_c_device_enqueue 1
+-#define __opencl_c_read_write_images 1
+ #define __opencl_c_program_scope_global_variables 1
+-#define __opencl_c_images 1
+ #endif
+ 
+ // Define header-only feature macros for OpenCL C 3.0.
+@@ -70,7 +68,6 @@
+ #define __opencl_c_atomic_order_seq_cst 1
+ #define __opencl_c_atomic_scope_device 1
+ #define __opencl_c_atomic_scope_all_devices 1
+-#define __opencl_c_read_write_images 1
+ #endif // defined(__SPIR__)
+ #endif // (__OPENCL_CPP_VERSION__ == 202100 || __OPENCL_C_VERSION__ == 300)
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Whenever OCL Clang is called from within compute runtime's compiler interface, certain OpenCL C extensions may not be enabled depending on the target HW platform. However, series of LLORG commits* override this behaviour by defining the feature macros unconditionally.

(*) https://reviews.llvm.org/D95776, https://reviews.llvm.org/D117899

Add a patch to delete such automatic definitions for image support macros. Once https://reviews.llvm.org/D141297 (LLVM 16) is integrated, an alternative approach could be to pass `-D__undef_<feature_macro>` within the Compute Runtime's compiler interface (in applicable situations) or at the OCL Clang's level (upon detecting the lack of extension-defining inputs to `-cl-ext`).