### PR TITLE
Works around windows x86 in-tree build if CMAKE_SIZEOF_VOID_P is not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,15 @@ use_rtti(FALSE)
 use_eh(TRUE)
 
 if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-    set(ADDR 32)
+  set(ADDR 32)
+elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(ADDR 64)
 else ()
-    set(ADDR 64)
+  # CMAKE_SIZEOF_VOID_P is not set on windows x86 somehow
+  message(STATUS "[OPENCL-CLANG] CMAKE_SIZEOF_VOID_P is not set")
+  if (WIN32 AND LLVM_BUILD_32_BITS)
+    set(ADDR 32)
+  endif()
 endif (CMAKE_SIZEOF_VOID_P EQUAL 4)
 
 # set windows binary suffix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ if (CMAKE_SIZEOF_VOID_P EQUAL 4)
 elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(ADDR 64)
 else ()
-  # CMAKE_SIZEOF_VOID_P is not set on windows x86 somehow
-  message(STATUS "[OPENCL-CLANG] CMAKE_SIZEOF_VOID_P is not set")
+  # CMAKE_SIZEOF_VOID_P might not be set on windows x86 in in-tree build
+  message(WARNING "[OPENCL-CLANG] CMAKE_SIZEOF_VOID_P is not set")
   if (WIN32 AND LLVM_BUILD_32_BITS)
     set(ADDR 32)
   endif()


### PR DESCRIPTION
Determine windows binary suffix via LLVM_BUILD_32_BITS in windows x86 if CMAKE_SIZEOF_VOID_P is not set