### PR TITLE
[RFC/DRAFT]: InitializeNativeTarget() instead of InitializeAllTargets()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,7 @@ target_link_libraries( ${TARGET_NAME}
                        LLVMX86Info
                        LLVMX86Disassembler
                        LLVMAnalysis
-                       LLVMCodeGen
+                       LLVMX86CodeGen
                        LLVMCore
                        LLVMipo
                        LLVMInstCombine
@@ -371,6 +371,7 @@ install(FILES opencl_clang.h
         DESTINATION include/cclang
         COMPONENT ${TARGET_NAME})
 
+add_custom_target(deploy DEPENDS install-${TARGET_NAME})
 #
 # Stripped PDB files
 #

--- a/opencl_clang.cpp
+++ b/opencl_clang.cpp
@@ -99,10 +99,9 @@ void CommonClangInitialize() {
       // llvm_shutdown before static object are destroyed, so we use atexit to
       // satisfy this requirement.
       atexit(CommonClangTerminate);
-      llvm::InitializeAllTargets();
-      llvm::InitializeAllAsmPrinters();
-      llvm::InitializeAllAsmParsers();
-      llvm::InitializeAllTargetMCs();
+      llvm::InitializeNativeTarget();
+      llvm::InitializeNativeTargetAsmPrinter();
+      llvm::InitializeNativeTargetAsmParser();
       lazyCCInit = false;
     }
   }


### PR DESCRIPTION
Fixes/works around: https://github.com/intel/opencl-clang/issues/417 

The other way around would be to link against all the Targets that LLVM Supports.