### PR TITLE
revert db7696e and 4a88836

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -90,7 +90,7 @@ static volatile bool lazyCCInit =
     true; // the flag must be 'volatile' to prevent caching in a CPU register
 static llvm::sys::Mutex lazyCCInitMutex;
 
-static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileMutex;
+llvm::ManagedStatic<llvm::sys::SmartMutex<true>> compileMutex;
 
 void CommonClangTerminate() {
   llvm::llvm_shutdown();
@@ -206,6 +206,7 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
   CommonClangInitialize();
 
   try {
+    llvm::sys::SmartScopedLock<true> compileGuard{*compileMutex};
     std::unique_ptr<OCLFEBinaryResult> pResult(new OCLFEBinaryResult());
 
     // Create the clang compiler
@@ -216,8 +217,6 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
     // Prepare error log
     llvm::raw_string_ostream err_ostream(pResult->getLogRef());
     {
-      llvm::sys::SmartScopedLock<true> compileGuard {*compileMutex};
-
       // Parse options
       optionsParser.processOptions(pszOptions, pszOptionsEx);
 
@@ -339,7 +338,6 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       err_ostream.flush();
     }
     {
-      llvm::sys::SmartScopedLock<true> compileGuard {*compileMutex};
       if (pBinaryResult) {
         *pBinaryResult = pResult.release();
       }

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -36,7 +36,7 @@ Copyright (c) Intel Corporation (2009-2017).
 
 using namespace llvm::opt;
 
-static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileOptionsMutex;
+extern llvm::ManagedStatic<llvm::sys::SmartMutex<true>> compileMutex;
 
 static const OptTable::Info ClangOptionsInfoTable[] = {
 #define PREFIX(NAME, VALUE)
@@ -320,7 +320,7 @@ extern "C" CC_DLL_EXPORT bool CheckCompileOptions(const char *pszOptions,
                                                   size_t uiUnknownOptionsSize) {
   // LLVM doesn't guarantee thread safety,
   // therefore we serialize execution of LLVM code.
-  llvm::sys::SmartScopedLock<true> compileOptionsGuard {*compileOptionsMutex};
+  llvm::sys::SmartScopedLock<true> compileOptionsGuard{*compileMutex};
 
   try {
     CompileOptionsParser optionsParser("200");


### PR DESCRIPTION
llvm-related variable initialization, clang::ExecuteCompilerInvocation and llvm-spirv aren't thread safe, at least for 90 branch.