### PR TITLE
Don't set CMAKE_CXX_FLAGS PARENT_SCOPE in macro use_rtti

### DIFF
--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -15,7 +15,6 @@ macro(use_rtti val)
             llvm_replace_compiler_option(CMAKE_CXX_FLAGS "-frtti" "-fno-rtti" )
         endif()
     endif()
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE )
 endmacro(use_rtti)
 
 #


### PR DESCRIPTION
cmake macro doesn't create new scope, so it is wrong to set PARENT_SCOPE for CMAKE_CXX_FLAGS.
In addition, in out-of-tree build, the parent scope doesn't exist and there is cmake warning.