### PR TITLE
revert db7696e and 4a88836 (#427)

### DIFF
--- a/common_clang.cpp
+++ b/common_clang.cpp
@@ -93,7 +93,7 @@ static volatile bool lazyCCInit =
     true; // the flag must be 'volatile' to prevent caching in a CPU register
 static llvm::sys::Mutex lazyCCInitMutex;
 
-static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileMutex;
+llvm::ManagedStatic<llvm::sys::SmartMutex<true>> compileMutex;
 
 void CommonClangTerminate() {
   llvm::llvm_shutdown();
@@ -222,6 +222,7 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
   CommonClangInitialize();
 
   try {
+    llvm::sys::SmartScopedLock<true> compileGuard{*compileMutex};
     std::unique_ptr<OCLFEBinaryResult> pResult(new OCLFEBinaryResult());
 
     // Create the clang compiler
@@ -231,8 +232,6 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
     CompileOptionsParser optionsParser(pszOpenCLVer);
     llvm::raw_string_ostream err_ostream(pResult->getLogRef());
     {
-        llvm::sys::SmartScopedLock<true> compileGuard {*compileMutex};
-
         // Parse options
         optionsParser.processOptions(pszOptions, pszOptionsEx);
         // Prepare error log
@@ -360,7 +359,6 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
         err_ostream.flush();
     }
     {
-        llvm::sys::SmartScopedLock<true> compileGuard {*compileMutex};
         if (pBinaryResult) {
           *pBinaryResult = pResult.release();
         }

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -38,7 +38,7 @@ Copyright (c) Intel Corporation (2009-2017).
 
 using namespace llvm::opt;
 
-static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileOptionsMutex;
+extern llvm::ManagedStatic<llvm::sys::SmartMutex<true>> compileMutex;
 
 static const OptTable::Info ClangOptionsInfoTable[] = {
 #define PREFIX(NAME, VALUE)
@@ -423,7 +423,7 @@ extern "C" CC_DLL_EXPORT bool CheckCompileOptions(const char *pszOptions,
                                                   size_t uiUnknownOptionsSize) {
   // LLVM doesn't guarantee thread safety,
   // therefore we serialize execution of LLVM code.
-  llvm::sys::SmartScopedLock<true> compileOptionsGuard {*compileOptionsMutex};
+  llvm::sys::SmartScopedLock<true> compileOptionsGuard{*compileMutex};
 
   try {
     CompileOptionsParser optionsParser("200");


### PR DESCRIPTION
llvm-related variable initialization, clang::ExecuteCompilerInvocation and llvm-spirv aren't thread safe.

(cherry picked from commit 76bc7f93d59190d0ffbedab9045b3a1b6effaa58)