### PR TITLE
revert db7696e and 4a88836 (#427)

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -39,7 +39,7 @@ Copyright (c) Intel Corporation (2009-2017).
 
 using namespace llvm::opt;
 
-static llvm::ManagedStatic<llvm::sys::SmartMutex<true> > compileOptionsMutex;
+extern llvm::ManagedStatic<llvm::sys::SmartMutex<true>> compileMutex;
 
 static const OptTable::Info ClangOptionsInfoTable[] = {
 #define PREFIX(NAME, VALUE)
@@ -430,7 +430,7 @@ extern "C" CC_DLL_EXPORT bool CheckCompileOptions(const char *pszOptions,
                                                   size_t uiUnknownOptionsSize) {
   // LLVM doesn't guarantee thread safety,
   // therefore we serialize execution of LLVM code.
-  llvm::sys::SmartScopedLock<true> compileOptionsGuard {*compileOptionsMutex};
+  llvm::sys::SmartScopedLock<true> compileOptionsGuard{*compileMutex};
 
   try {
     CompileOptionsParser optionsParser("200");


### PR DESCRIPTION
llvm-related variable initialization, clang::ExecuteCompilerInvocation and llvm-spirv aren't thread safe, at least for 90 branch.

(cherry picked from commit 76bc7f93d59190d0ffbedab9045b3a1b6effaa58)