### PR TITLE
Port "Add clang patches to fix Image types related issue"

### DIFF
--- a/patches/clang/0002-Remove-wrong-check-of-__opencl_c_images-feature-macr.patch
+++ b/patches/clang/0002-Remove-wrong-check-of-__opencl_c_images-feature-macr.patch
@@ -1,0 +1,37 @@
+From 9780cc0e044c73dcd549c67a1278a4ff7daf3b01 Mon Sep 17 00:00:00 2001
+From: Marcin Naczk <marcin.naczk@intel.com>
+Date: Fri, 4 Nov 2022 15:41:16 +0100
+Subject: [PATCH] Remove wrong check of __opencl_c_images feature macro
+
+Deleted mechanism that wrongly assumes that
+all functions that use image types must be under
+__opencl_c_images feature macro
+Mechanism added by https://reviews.llvm.org/D103911
+More info on github issue:
+https://github.com/llvm/llvm-project/issues/58017
+---
+ clang/lib/Sema/SemaType.cpp | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/clang/lib/Sema/SemaType.cpp b/clang/lib/Sema/SemaType.cpp
+index ab47e9f03eaf..f72c2fb57ddd 100644
+--- a/clang/lib/Sema/SemaType.cpp
++++ b/clang/lib/Sema/SemaType.cpp
+@@ -1741,13 +1741,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
+     // __opencl_c_3d_image_writes feature. OpenCL C v3.0 API s4.2 - For devices
+     // that support OpenCL 3.0, cl_khr_3d_image_writes must be returned when and
+     // only when the optional feature is supported
+-    if ((Result->isImageType() || Result->isSamplerT()) &&
+-        (IsOpenCLC30Compatible &&
+-         !OpenCLOptions.isSupported("__opencl_c_images", S.getLangOpts()))) {
+-      S.Diag(DS.getTypeSpecTypeLoc(), diag::err_opencl_requires_extension)
+-          << 0 << Result << "__opencl_c_images";
+-      declarator.setInvalidType();
+-    } else if (Result->isOCLImage3dWOType() &&
++    if (Result->isOCLImage3dWOType() &&
+                !OpenCLOptions.isSupported("cl_khr_3d_image_writes",
+                                           S.getLangOpts())) {
+       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_opencl_requires_extension)
+-- 
+2.33.0.windows.1
+

--- a/patches/clang/0003-Fix-checking-mechanism-for-read_write-Image-type.patch
+++ b/patches/clang/0003-Fix-checking-mechanism-for-read_write-Image-type.patch
@@ -1,0 +1,34 @@
+From bb5e22800857f7dda9a2491a4f2fc7387d4205b0 Mon Sep 17 00:00:00 2001
+From: Marcin Naczk <marcin.naczk@intel.com>
+Date: Fri, 4 Nov 2022 15:45:17 +0100
+Subject: [PATCH] Fix checking mechanism for read_write Image type
+
+The commit
+https://github.com/llvm/llvm-project/commit/91a0b464a853821734db8b1c521df03f8e2e56e7
+Enabled opencl feature macro __opencl_c_read_write_images
+by default for the SPIR and SPIR-V targets
+therefore the mechanism of checking read_write image type
+should take into account if the target is SPIR or SPIR-V
+---
+ clang/lib/Sema/SemaDeclAttr.cpp | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/clang/lib/Sema/SemaDeclAttr.cpp b/clang/lib/Sema/SemaDeclAttr.cpp
+index e76e7c608e0c..2d60d2b03169 100644
+--- a/clang/lib/Sema/SemaDeclAttr.cpp
++++ b/clang/lib/Sema/SemaDeclAttr.cpp
+@@ -7823,8 +7823,9 @@ static void handleOpenCLAccessAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+       bool ReadWriteImagesUnsupported =
+           (S.getLangOpts().getOpenCLCompatibleVersion() < 200) ||
+           (S.getLangOpts().getOpenCLCompatibleVersion() == 300 &&
+-           !S.getOpenCLOptions().isSupported("__opencl_c_read_write_images",
+-                                             S.getLangOpts()));
++           !S.getOpenCLOptions().isSupported("__opencl_c_read_write_images", S.getLangOpts()) &&
++           !S.getASTContext().getTargetInfo().getTriple().isSPIR() &&
++           !S.getASTContext().getTargetInfo().getTriple().isSPIRV());
+       if (ReadWriteImagesUnsupported || DeclTy->isPipeType()) {
+         S.Diag(AL.getLoc(), diag::err_opencl_invalid_read_write)
+             << AL << PDecl->getType() << DeclTy->isImageType();
+-- 
+2.33.0.windows.1
+


### PR DESCRIPTION
This is WA for clang the issue
https://github.com/llvm/llvm-project/issues/58017
Patches are needed because the proper fixes will be avaiable only
for llvm versions greater than LLVM15

This is a cherry-pick of commit c08746e from CClang 14 branch.