### PR TITLE
Partially revert 53b8f126 on linux (#460)

### DIFF
--- a/opencl_clang.cpp
+++ b/opencl_clang.cpp
@@ -208,7 +208,9 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
   CommonClangInitialize();
 
   try {
+#ifdef _WIN32
     llvm::sys::SmartScopedLock<true> compileGuard{*compileMutex};
+#endif
     std::unique_ptr<OCLFEBinaryResult> pResult(new OCLFEBinaryResult());
 
     // Create the clang compiler
@@ -220,6 +222,9 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
     // Prepare error log
     llvm::raw_string_ostream err_ostream(pResult->getLogRef());
     {
+#ifndef _WIN32
+      llvm::sys::SmartScopedLock<true> compileGuard{*compileMutex};
+#endif
       // Parse options
       optionsParser.processOptions(pszOptions, pszOptionsEx);
 
@@ -336,6 +341,9 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
       err_ostream.flush();
     }
     {
+#ifndef _WIN32
+      llvm::sys::SmartScopedLock<true> compileGuard{*compileMutex};
+#endif
       if (pBinaryResult) {
         *pBinaryResult = pResult.release();
       }


### PR DESCRIPTION
The issue in 53b8f126 isn't observed on linux.
This allows parallel execution of clang::ExecuteCompilerInvocation and parallel execution of llvm::writeSpirv.
This improves performance of multi-threaded OpenCL tests on linux.

(cherry picked from commit cf95b338d14685e4f3402ab1828bef31d48f1fd6)