### PR TITLE
Add 'clangSerialization' to CMakeLists (fix downstream link error).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ else()
     clangBasic
     clangFrontend
     clangFrontendTool
+    clangSerialization
   )
 endif()
 


### PR DESCRIPTION
The following link error occurs in downstream after 1bda00e358:

```
ld: error: undefined symbol: clang::PCHContainerOperations::PCHContainerOperations()
>>> referenced by opencl_clang.cpp
>>>               _deps/opencl-clang-build/CMakeFiles/common_clang.dir/opencl_clang.cpp.o:(Compile)
icpx: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is similar to the link error seen in
https://reviews.llvm.org/D157078, which was resolved in the same way
(https://reviews.llvm.org/rG36daf3532d91bb3e61d631edceea77ebb8417801).

This patch just adds 'clangSerialization' to the link libraries to
resolve the issue.
