### PR TITLE
Keep cl-mad-enable and ffp-contract consistent.

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -256,6 +256,12 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
     }
   }
 
+  // ffp-contract is on by default for clang, we turn off it if cl-mad-enable is
+  // not specified.
+  if (std::find(effectiveArgs.begin(), effectiveArgs.end(), "-cl-mad-enable") ==
+      effectiveArgs.end())
+    effectiveArgs.push_back("-ffp-contract=off");
+
 #ifdef PCH_EXTENSION
   std::map<std::string, bool> extMap;
   llvm::SmallVector<llvm::StringRef> extVec;


### PR DESCRIPTION
ffp-contract is on by default for clang, but cl-mad-enable is off by default. We turn off ffp-contract if cl-mad-enable is not specified.