### PR TITLE
Use llvm-config to fix link error if llvm is pre-built locally static or shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,9 +302,8 @@ if(USE_PREBUILT_LLVM AND UNIX)
   # llvm_map_components_to_libnames(... all) returns empty string if llvm is
   # pre-built locally in either static or shared type in Ubuntu 22.04 container.
   execute_process(COMMAND llvm-config --libs all OUTPUT_VARIABLE ALL_LIBS)
-  string(STRIP ${ALL_LIBS} ALL_LIBS_STRIP)
-  string(REGEX REPLACE "[ ]*-l" ";" ALL_LLVM_LIBS ${ALL_LIBS_STRIP})
-  set(ALL_LLVM_LIBS "${ALL_LLVM_LIBS};LLVMSPIRVLib")
+  string(REGEX REPLACE "( |\r|\n|-l)+" ";" ALL_LLVM_LIBS ${ALL_LIBS})
+  set(ALL_LLVM_LIBS "LLVMSPIRVLib${ALL_LLVM_LIBS}")
 else()
   llvm_map_components_to_libnames(ALL_LLVM_LIBS all)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,8 +298,17 @@ else()
   )
 endif()
 
+if(USE_PREBUILT_LLVM AND UNIX)
+  # llvm_map_components_to_libnames(... all) returns empty string if llvm is
+  # pre-built locally in either static or shared type in Ubuntu 22.04 container.
+  execute_process(COMMAND llvm-config --libs all OUTPUT_VARIABLE ALL_LIBS)
+  string(STRIP ${ALL_LIBS} ALL_LIBS_STRIP)
+  string(REGEX REPLACE "[ ]*-l" ";" ALL_LLVM_LIBS ${ALL_LIBS_STRIP})
+  set(ALL_LLVM_LIBS "${ALL_LLVM_LIBS};LLVMSPIRVLib")
+else()
+  llvm_map_components_to_libnames(ALL_LLVM_LIBS all)
+endif()
 set(OPENCL_CLANG_EXCLUDE_LIBS_FROM_ALL "" CACHE STRING "Space-separated list of LLVM libraries to exclude from all")
-llvm_map_components_to_libnames(ALL_LLVM_LIBS all)
 if (NOT "${OPENCL_CLANG_EXCLUDE_LIBS_FROM_ALL}" STREQUAL "")
   list(REMOVE_ITEM ALL_LLVM_LIBS ${OPENCL_CLANG_EXCLUDE_LIBS_FROM_ALL})
 endif()


### PR DESCRIPTION
llvm_map_components_to_libnames is empty in these cases.
This fixes link error in Ubuntu 22.04 container.  #484 and #454