### PR TITLE
Use find_program to find llvm-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,14 @@ endif()
 if(USE_PREBUILT_LLVM AND UNIX)
   # llvm_map_components_to_libnames(... all) returns empty string if llvm is
   # pre-built locally in either static or shared type in Ubuntu 22.04 container.
-  execute_process(COMMAND llvm-config --libs all OUTPUT_VARIABLE ALL_LIBS)
+  find_program(LLVM_CONFIG_EXE
+    NAMES llvm-config-17 llvm-config-17.0 llvm-config170 llvm-config
+    PATHS ${LLVM_BINARY_DIR} ${LLVM_BINARY_DIR}/bin)
+  if(NOT LLVM_CONFIG_EXE)
+    message(FATAL_ERROR "[OPENCL-CLANG] llvm-config is not found")
+  endif()
+
+  execute_process(COMMAND ${LLVM_CONFIG_EXE} --libs all OUTPUT_VARIABLE ALL_LIBS)
   string(REGEX REPLACE "( |\r|\n|-l)+" ";" ALL_LLVM_LIBS ${ALL_LIBS})
   set(ALL_LLVM_LIBS "LLVMSPIRVLib${ALL_LLVM_LIBS}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ if(USE_PREBUILT_LLVM AND UNIX)
   # llvm_map_components_to_libnames(... all) returns empty string if llvm is
   # pre-built locally in either static or shared type in Ubuntu 22.04 container.
   find_program(LLVM_CONFIG_EXE
-    NAMES llvm-config-17 llvm-config-17.0 llvm-config170 llvm-config
+    NAMES llvm-config-${PREFERRED_LLVM_VERSION} llvm-config
     PATHS ${LLVM_BINARY_DIR} ${LLVM_BINARY_DIR}/bin)
   if(NOT LLVM_CONFIG_EXE)
     message(FATAL_ERROR "[OPENCL-CLANG] llvm-config is not found")


### PR DESCRIPTION
#497 llvm-config may have a different name in the default path.
On Ubuntu 22.04,
* https://apt.llvm.org/llvm.sh installs llvm-config-17 to /usr/bin
  folder. It is a symlink to /usr/lib/llvm-17/bin/llvm-config.
* If llvm 17 is built from source, the name is /usr/local/bin/llvm-config