### PR TITLE
[CI] Set github workflow scheduled-verification branches to 14~18

### DIFF
--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -28,10 +28,10 @@ jobs:
           ref_opencl-clang: main
 
   verify-release-branches:
-    name: Verify `ocl-open-*` release branches
+    name: Verify `ocl-open-${{ matrix.llvm_version }}` release branch
     strategy:
       matrix:
-        llvm_version: [ 10, 11, 12, 13, 14, 15 ]
+        llvm_version: [ 14, 15, 16, 17, 18 ]
     runs-on: ubuntu-22.04
     steps:
 


### PR DESCRIPTION
Don't run on branches older than 14.