### PR TITLE
[Backport] Do not apply patches if sub non-git repo is located in a git repo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(LLVM_USE_HOST_TOOLS AND OPENCL_CLANG_BUILD_EXTERNAL)
   llvm_create_cross_target(${PROJECT_NAME} NATIVE "" Release)
 endif()
 
+option(LLVMSPIRV_INCLUDED_IN_LLVM
+  "Set to ON if libLLVMSPIRVLib is linked into libLLVM" ON)
+option(APPLY_PATCHES "Apply local patches" ON)
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(USE_PREBUILT_LLVM ON)
 
@@ -61,8 +65,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CMAKE_CXX_STANDARD 14)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-    option(LLVMSPIRV_INCLUDED_IN_LLVM
-      "Set to ON if libLLVMSPIRVLib is linked into libLLVM" ON)
     if(LLVMSPIRV_INCLUDED_IN_LLVM)
         message(STATUS "[OPENCL-CLANG] Assuming that libLLVMSPIRVLib is linked into libLLVM")
     else(LLVMSPIRV_INCLUDED_IN_LLVM)
@@ -152,16 +154,20 @@ if(NOT USE_PREBUILT_LLVM)
     get_filename_component(LLVM_MONOREPO_DIR ${LLVM_SOURCE_DIR} DIRECTORY)
     set(LLVM_PATCHES_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
                           ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang)
-    apply_patches(${LLVM_MONOREPO_DIR}
-                  "${LLVM_PATCHES_DIRS}"
-                  ${LLVM_BASE_REVISION}
-                  ${TARGET_BRANCH}
-                  ret)
-    apply_patches(${SPIRV_SOURCE_DIR}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/spirv
-                  ${SPIRV_BASE_REVISION}
-                  ${TARGET_BRANCH}
-                  ret)
+
+    if(APPLY_PATCHES)
+      message(STATUS "APPLY_PATCHES is enabled.")
+      apply_patches(${LLVM_MONOREPO_DIR}
+                    "${LLVM_PATCHES_DIRS}"
+                    ${LLVM_BASE_REVISION}
+                    ${TARGET_BRANCH})
+      apply_patches(${SPIRV_SOURCE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/patches/spirv
+                    ${SPIRV_BASE_REVISION}
+                    ${TARGET_BRANCH})
+    else()
+      message(STATUS "APPLY_PATCHES is disabled, skip patch apply process.")
+    endif()
 endif(NOT USE_PREBUILT_LLVM)
 
 #

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -106,8 +106,10 @@ function(apply_patches repo_dir patches_dir base_revision target_branch ret)
         OUTPUT_QUIET
     )
     if(patches_needed EQUAL 128) # not a git repo
-        set(ret_not_git_repo 1)
-	elseif(patches_needed) # The target branch doesn't exist
+      set(${ret} True PARENT_SCOPE)
+      message(STATUS "[OPENCL-CLANG] ${repo_dir} is not a git repository")
+      return()
+    elseif(patches_needed EQUAL 1) # The target branch doesn't exist
         list(SORT patches)
         is_valid_revision(${repo_dir} ${base_revision} exists_base_rev)
 
@@ -147,7 +149,7 @@ function(apply_patches repo_dir patches_dir base_revision target_branch ret)
                 endif()
             endif()
         endforeach(patch)
-    else() # The target branch already exists
+    elseif(patches_needed EQUAL 0) # The target branch already exists
         execute_process( # Check it out
             COMMAND ${GIT_EXECUTABLE} checkout ${target_branch}
             WORKING_DIRECTORY ${repo_dir}
@@ -155,7 +157,7 @@ function(apply_patches repo_dir patches_dir base_revision target_branch ret)
             RESULT_VARIABLE ret_check_out
         )
     endif()
-	if (NOT (ret_not_git_repo OR ret_check_out OR ret_apply_patch))
+	if (NOT (ret_check_out OR ret_apply_patch))
         set(${ret} True PARENT_SCOPE)
     else()
         message(FATAL_ERROR "[OPENCL-CLANG] Failed to apply patch!")


### PR DESCRIPTION
[Backport] Do not apply patches if repo is a not a git repo. https://github.com/intel/opencl-clang/pull/539
[Backport] Do not apply patches if sub non-git repo is located in a git repo. https://github.com/intel/opencl-clang/pull/545
Also add an option to control patch apply which is default on. Pass -DAPPLY_PATCHES=OFF will skip patch apply process.
