### PR TITLE
[Backport] Do not apply patches if sub non-git repo is located in a git repo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(CMAKE_CROSSCOMPILING AND OPENCL_CLANG_BUILD_EXTERNAL)
   llvm_create_cross_target(${PROJECT_NAME} NATIVE "" Release)
 endif()
 
+option(LLVMSPIRV_INCLUDED_IN_LLVM
+  "Set to ON if libLLVMSPIRVLib is linked into libLLVM" ON)
+option(APPLY_PATCHES "Apply local patches" ON)
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(USE_PREBUILT_LLVM ON)
 
@@ -61,8 +65,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-    option(LLVMSPIRV_INCLUDED_IN_LLVM
-      "Set to ON if libLLVMSPIRVLib is linked into libLLVM" ON)
     if(LLVMSPIRV_INCLUDED_IN_LLVM)
         message(STATUS "[OPENCL-CLANG] Assuming that libLLVMSPIRVLib is linked into libLLVM")
     else(LLVMSPIRV_INCLUDED_IN_LLVM)
@@ -159,18 +161,26 @@ if(NOT USE_PREBUILT_LLVM)
         )
     endif()
 
-    set(CLANG_BASE_REVISION release/17.x)
+    set(LLVM_BASE_REVISION release/17.x)
     set(SPIRV_BASE_REVISION llvm_release_170)
     set(TARGET_BRANCH "ocl-open-170")
+    get_filename_component(LLVM_MONOREPO_DIR ${LLVM_SOURCE_DIR} DIRECTORY)
+    set(LLVM_PATCHES_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+                          ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang)
 
-    apply_patches(${CLANG_SOURCE_DIR}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang
-                  ${CLANG_BASE_REVISION}
-                  ${TARGET_BRANCH})
-    apply_patches(${SPIRV_SOURCE_DIR}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/spirv
-                  ${SPIRV_BASE_REVISION}
-                  ${TARGET_BRANCH})
+   if(APPLY_PATCHES)
+      message(STATUS "APPLY_PATCHES is enabled.")
+      apply_patches(${LLVM_MONOREPO_DIR}
+                    "${LLVM_PATCHES_DIRS}"
+                    ${LLVM_BASE_REVISION}
+                    ${TARGET_BRANCH})
+      apply_patches(${SPIRV_SOURCE_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/patches/spirv
+                    ${SPIRV_BASE_REVISION}
+                    ${TARGET_BRANCH})
+    else()
+      message(STATUS "APPLY_PATCHES is disabled, skip patch apply process.")
+    endif()
 endif(NOT USE_PREBUILT_LLVM)
 
 #

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -56,7 +56,6 @@ function(is_backport_patch_present patch_path repo_dir patch_in_branch)
         WORKING_DIRECTORY ${repo_dir}
         RESULT_VARIABLE patch_not_in_branches
         OUTPUT_QUIET
-        ERROR_QUIET
         )
     if(patch_not_in_branches)
         set(patch_in_branch False PARENT_SCOPE) # The patch is not present in local branch
@@ -73,7 +72,6 @@ function(is_valid_revision repo_dir revision return_val)
         COMMAND ${GIT_EXECUTABLE} log -1 ${revision}
         WORKING_DIRECTORY ${repo_dir}
         RESULT_VARIABLE output_var
-        ERROR_QUIET
         OUTPUT_QUIET
         )
     if(${output_var} EQUAL 0)
@@ -101,10 +99,12 @@ function(apply_patches repo_dir patches_dir base_revision target_branch)
         COMMAND ${GIT_EXECUTABLE} rev-parse --verify --no-revs -q ${target_branch}
         WORKING_DIRECTORY ${repo_dir}
         RESULT_VARIABLE patches_needed
-        ERROR_QUIET
         OUTPUT_QUIET
     )
-    if(patches_needed) # The target branch doesn't exist
+    if(patches_needed EQUAL 128) # not a git repo
+      message(STATUS "[OPENCL-CLANG] ${repo_dir} is not a git repository")
+      return()
+    elseif(patches_needed EQUAL 1) # The target branch doesn't exist
         list(SORT patches)
         is_valid_revision(${repo_dir} ${base_revision} exists_base_rev)
 
@@ -114,7 +114,6 @@ function(apply_patches repo_dir patches_dir base_revision target_branch)
                 WORKING_DIRECTORY ${repo_dir}
                 OUTPUT_VARIABLE repo_head
                 OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_QUIET
                 )
             message(STATUS "[OPENCL-CLANG] ref ${base_revision} not exists in repository, using current HEAD:${repo_head}")
             set(base_revision ${repo_head})
@@ -134,21 +133,22 @@ function(apply_patches repo_dir patches_dir base_revision target_branch)
                 message(STATUS "[OPENCL-CLANG] Patch ${patch} is already in local branch - ignore patching")
             else()
                 execute_process( # Apply the patch
-                    COMMAND ${GIT_EXECUTABLE} am --3way --ignore-whitespace ${patch}
+                    COMMAND ${GIT_EXECUTABLE} am --3way --ignore-whitespace -C0 ${patch}
                     WORKING_DIRECTORY ${repo_dir}
                     OUTPUT_VARIABLE patching_log
-                    ERROR_QUIET
                 )
                 message(STATUS "[OPENCL-CLANG] Not present - ${patching_log}")
             endif()
         endforeach(patch)
-    else() # The target branch already exists
+    elseif(patches_needed EQUAL 0) # The target branch already exists
         execute_process( # Check it out
             COMMAND ${GIT_EXECUTABLE} checkout ${target_branch}
             WORKING_DIRECTORY ${repo_dir}
-            ERROR_QUIET
             OUTPUT_QUIET
         )
+    endif()
+    if (ret_check_out OR ret_apply_patch)
+      message(FATAL_ERROR "[OPENCL-CLANG] Failed to apply patch!")
     endif()
 endfunction()
 

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -93,7 +93,13 @@ function(apply_patches repo_dir patches_dir base_revision target_branch)
         return()
     endif()
 
-    message(STATUS "[OPENCL-CLANG] Patching repository ${repo_dir}")
+    # Check if it's a git repo
+    if(EXISTS "${repo_dir}/.git")
+      message(STATUS "[OPENCL-CLANG] Patching repository ${repo_dir}")
+    else()
+      message(STATUS "[OPENCL-CLANG][Warning] ${repo_dir} is not a git repository, therefore, local patches are not applied")
+      return()
+    endif()
     # Check if the target branch already exists
     execute_process(
         COMMAND ${GIT_EXECUTABLE} rev-parse --verify --no-revs -q ${target_branch}
@@ -101,10 +107,7 @@ function(apply_patches repo_dir patches_dir base_revision target_branch)
         RESULT_VARIABLE patches_needed
         OUTPUT_QUIET
     )
-    if(patches_needed EQUAL 128) # not a git repo
-      message(STATUS "[OPENCL-CLANG] ${repo_dir} is not a git repository")
-      return()
-    elseif(patches_needed EQUAL 1) # The target branch doesn't exist
+    if(patches_needed EQUAL 1) # The target branch doesn't exist
         list(SORT patches)
         is_valid_revision(${repo_dir} ${base_revision} exists_base_rev)
 
@@ -147,8 +150,10 @@ function(apply_patches repo_dir patches_dir base_revision target_branch)
             OUTPUT_QUIET
         )
     endif()
-    if (ret_check_out OR ret_apply_patch)
-      message(FATAL_ERROR "[OPENCL-CLANG] Failed to apply patch!")
+    if (NOT (ret_check_out OR ret_apply_patch))
+        message(STATUS "[OPENCL-CLANG] Applied patch successfully!")
+    else()
+        message(FATAL_ERROR "[OPENCL-CLANG] Failed to apply patch!")
     endif()
 endfunction()
 


### PR DESCRIPTION
[Backport] Do not apply patches if repo is a not a git repo. https://github.com/intel/opencl-clang/pull/539
[Backport] Do not apply patches if sub non-git repo is located in a git repo. https://github.com/intel/opencl-clang/pull/545
Also add an option to control patch apply which is default on. Pass -DAPPLY_PATCHES=OFF will skip patch apply process.
Update LLVM_BASE_REVISION.