### PR TITLE
Add automatic patch release generation

### DIFF
--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -1,0 +1,115 @@
+name: Generate patch releases
+
+on:
+  workflow_dispatch:
+  schedule:
+    # First day of every month
+    - cron: '0 0 1 * *'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_branch: ${{steps.latest_branch.outputs.latest_branch}}
+      branches_json: ${{steps.release_branches.outputs.branches_json}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+      - name: Get latest llvm_release branch
+        id: latest_branch
+        run: |
+          git branch -r \
+          | grep 'ocl-open-' \
+          | sed -E 's/.*\/ocl-open-([0-9]+)/\1/' \
+          | sort -n -r \
+          | head -1 \
+          | xargs printf "latest_branch=ocl-open-%s" \
+          >> $GITHUB_OUTPUT
+      - name: Get branch list
+        id: release_branches
+        run: |
+          git branch -r \
+          | grep "origin/ocl-open-" \
+          | sed -E 's/\ *origin\/([^\ ]*)/\"\1\"/' \
+          | paste -sd',' \
+          | xargs -0 -d"\n" printf 'branches_json={"branch":[%s]}' \
+          >> $GITHUB_OUTPUT
+  release:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix: ${{fromJson(needs.setup.outputs.branches_json)}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            ref: ${{ matrix.branch }}
+            fetch-depth: 0
+      - name: Get commits info
+        id: versions
+        run: |
+            export LATEST_VERSION=\
+            "$(git describe --tags --abbrev=0 --match 'v*')"
+            export LLVM_VERSION=$(echo $LATEST_VERSION \
+            | sed -E 's/v([0-9]+\.[0-9]+)\.([0-9]+).*/\1/')
+            export PATCH=$(echo $LATEST_VERSION \
+            | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\2/')
+            echo "llvm_version=$LLVM_VERSION" >> $GITHUB_OUTPUT
+            echo "patch=$PATCH" >> $GITHUB_OUTPUT
+            echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+            echo "release_version=${LLVM_VERSION}.$((${PATCH}+1))" \
+            >> $GITHUB_OUTPUT
+            git rev-list ${LATEST_VERSION}..HEAD --count \
+            | xargs printf "commits_since_last_release=%d\n" >> $GITHUB_OUTPUT
+            git rev-parse HEAD | xargs printf "last_commit=%s\n" >> $GITHUB_OUTPUT
+      - name: Get SPIRV-LLVM-Translator and llvm-project latest tags
+        id: llvm-spirv-versions
+        run: |
+          export SPIRV_PATCH=\
+          $(git ls-remote --tags \
+          "https://github.com/KhronosGroup/SPIRV-LLVM-Translator" \
+          "refs/tags/v${{ steps.versions.outputs.llvm_version }}.[0-9]" \
+          "refs/tags/v${{ steps.versions.outputs.llvm_version }}.[0-9][0-9]" \
+          | awk '{print $2}' \
+          | sed -E 's/refs\/tags\/v${{ steps.versions.outputs.llvm_version }}.([0-9]+)/\1/' \
+          | sort -n \
+          | tail -1)
+          echo "spirv_patch=${SPIRV_PATCH}" >> $GITHUB_OUTPUT
+          export LLVM_PATCH=\
+          $(git ls-remote --tags \
+          "https://github.com/llvm/llvm-project" \
+          "refs/tags/llvmorg-${{ steps.versions.outputs.llvm_version }}.[0-9]" \
+          "refs/tags/llvmorg-${{ steps.versions.outputs.llvm_version }}.[0-9][0-9]" \
+          | awk '{print $2}' \
+          | sed -E 's/refs\/tags\/llvmorg-${{ steps.versions.outputs.llvm_version }}.([0-9]+)/\1/' \
+          | sort -n \
+          | tail -1)
+          echo "llvm_patch=${LLVM_PATCH}" >> $GITHUB_OUTPUT
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ steps.versions.outputs.commits_since_last_release != 0 }}
+        with:
+            # Setting tag to have format:
+            # %latest llvm version%.%latest patch + 1%
+            tag_name: v${{ steps.versions.outputs.release_version }}
+            # We have to set this so tag is set on the branch we are releasing
+            target_commitish: ${{ steps.versions.outputs.last_commit }}
+            # We don't want to mark patch releases latest unless it is latest
+            # major version
+            make_latest: >-
+              ${{ needs.setup.outputs.latest_branch == matrix.branch }}
+            name: >
+              opencl-clang linked against LLVM 
+              v${{ steps.versions.outputs.llvm_version }}
+              libraries
+            # TODO: update
+            body: "This release is linked against LLVM \
+              v${{ steps.versions.outputs.llvm_version }}.${{ steps.llvm-spirv-versions.outputs.llvm_patch }} \
+              and SPIR-V LLVM translator \
+              v${{ steps.versions.outputs.llvm_version }}.${{ steps.llvm-spirv-versions.outputs.spirv_patch }}. \
+              Full Changelog: ${{ github.server_url }}/\
+              ${{ github.repository }}/compare/\
+              ${{ steps.versions.outputs.latest_version }}...\
+              v${{ steps.versions.outputs.release_version }}"


### PR DESCRIPTION
Similarly to https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2586 adds automated patch release generation.

Examples of releases could be found in my fork: https://github.com/ZzEeKkAa/opencl-clang/releases

For the final result look at https://github.com/ZzEeKkAa/opencl-clang/releases/tag/v17.0.5 . On other releases I've been playing around with release message.

Fixes #537 