### PR TITLE
Wrap linker flags with LINKER: prefix for IntelLLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,13 +326,12 @@ if (WIN32)
     file(TO_NATIVE_PATH ${RT_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${TARGET_NAME}_stripped.pdb PDB_NAME)
     if (${MSVC_VERSION} EQUAL 1500)
         # Visual Studio 2008
-        set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS    "${LINK_FLAGS} /PDBSTRIPPED:${PDB_NAME}")
+        set_property(TARGET ${TARGET_NAME} APPEND PROPERTY LINK_OPTIONS "LINKER:/PDBSTRIPPED:${PDB_NAME}")
     else (${MSVC_VERSION} EQUAL 1500)
         # Visual Studio 2010 (assumed if not Visual Studio 2008)
         # This is a fix due to a bug in CMake, Does not add the flag /DEBUG to the linker flags in Release mode.
         # The /DEBUG flag is required in order to create stripped pdbs.
-        set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS_DEBUG    "${LINK_FLAGS_DEBUG} /PDBSTRIPPED:${PDB_NAME}")
-        set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS_RELEASE    "${LINK_FLAGS_RELEASE} /DEBUG /PDBSTRIPPED:${PDB_NAME}")
+        set_property(TARGET ${TARGET_NAME} APPEND PROPERTY LINK_OPTIONS $<$<CONFIG:Release>:LINKER:/DEBUG> "$<$<CONFIG:Debug,Release>:LINKER:/PDBSTRIPPED:${PDB_NAME}>")
     endif (${MSVC_VERSION} EQUAL 1500)
     if (INSTALL_PDBS)
         install(FILES ${RT_OUTPUT_DIRECTORY}/\${BUILD_TYPE}/${TARGET_NAME}.pdb DESTINATION bin)


### PR DESCRIPTION
The Intel C++ compiler passes linker flags through the compiler driver since CMake 3.25, therefore they need to be escaped with the `LINKER:` prefix.
This expands to the empty string in MSVC and clang-cl or older versions of CMake, so no special handling is needed for that.

Fixes: #552