### PR TITLE
[CMake][MSVC] Wrap more linker flags for IntelLLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,8 +300,8 @@ add_llvm_library(${TARGET_NAME} SHARED
 if (WIN32)
     # Enable compiler generation of Control Flow Guard security checks.
     target_compile_options(${TARGET_NAME} PUBLIC "/guard:cf")
-    set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY
-        LINK_FLAGS "/DYNAMICBASE /GUARD:CF")
+    set_property(TARGET ${TARGET_NAME} APPEND PROPERTY
+        LINK_OPTIONS "LINKER:/DYNAMICBASE" "LINKER:/GUARD:CF")
 
 elseif(UNIX)
     set_property(TARGET ${TARGET_NAME} APPEND_STRING PROPERTY


### PR DESCRIPTION
My previous pass missed some flags because I used `-Werror=unknown-argument`, but `/D` and `/G` are accepted by clang (even when only linking), but mean different things than intended for `link.exe`.
Wrapping the linker with a script revealed these flags.

The approach I used to find these is documented as github gist here: https://gist.github.com/Maetveis/00567488f0d6ff74095d91ed306fafc5