### PR TITLE
Properly pass no-opaque-pointers to spirv translator

### DIFF
--- a/opencl_clang.cpp
+++ b/opencl_clang.cpp
@@ -314,6 +314,7 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
           pResult->GetIRSize());
       std::unique_ptr<llvm::MemoryBuffer> MB = llvm::MemoryBuffer::getMemBuffer(LLVM_IR, pResult->GetIRName(), false);
       llvm::LLVMContext Context;
+      Context.setOpaquePointers(optionsParser.hasOpaquePointers());
       auto E = llvm::getOwningLazyBitcodeModule(std::move(MB), Context,
           /*ShouldLazyLoadMetadata=*/true);
       llvm::logAllUnhandledErrors(E.takeError(), err_ostream, "error: ");

--- a/options.h
+++ b/options.h
@@ -145,7 +145,7 @@ private:
 class CompileOptionsParser {
 public:
   CompileOptionsParser(const char *pszOpenCLVersion)
-      : m_commonFilter(pszOpenCLVersion), m_emitSPIRV(false), m_optDisable(false) {}
+      : m_commonFilter(pszOpenCLVersion), m_emitSPIRV(false), m_optDisable(false), m_opaquePointers(true) {}
 
   //
   // Validates and prepares the effective options to pass to clang upon
@@ -178,6 +178,7 @@ public:
 
   bool hasEmitSPIRV() const { return m_emitSPIRV; }
   bool hasOptDisable() const { return m_optDisable; }
+  bool hasOpaquePointers() const { return m_opaquePointers; }
 
 private:
   OpenCLCompileOptTable m_optTbl;
@@ -187,6 +188,7 @@ private:
   std::string m_sourceName;
   bool m_emitSPIRV;
   bool m_optDisable;
+  bool m_opaquePointers;
 };
 
 // Tokenize a string into tokens separated by any char in 'delims'.

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -418,6 +418,9 @@ void CompileOptionsParser::processOptions(const char *pszOptions,
       m_emitSPIRV = true;
       continue;
     }
+    else if (it->compare("-no-opaque-pointers") == 0) {
+      m_opaquePointers = false;
+    }
     m_effectiveArgsRaw.push_back(it->c_str());
   }
 }


### PR DESCRIPTION
Previously, SPIRV translator treated all LLVM IR as using opaque pointers, even if the LLVM IR was build with the typed pointers.