### PR TITLE
Upgrade cmake_minimum_required to 3.20.0 to align with llvm-project main branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.20.0)
 
 if(NOT DEFINED OPENCL_CLANG_BUILD_EXTERNAL)
   # check if we build inside llvm or not


### PR DESCRIPTION
llvm-project already upgraded from 3.13.4 to 3.20.0 in LLVM 17.0.0