### PR TITLE
[ocl-open-140] Update cmake_minimum_required VERSION to 3.13.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13.4)
 
 if(NOT DEFINED BASE_LLVM_VERSION)
   set(BASE_LLVM_VERSION 14.0.0)


### PR DESCRIPTION
Align version with llvm release/14.x branch. Fix cmake configure error:
`Compatibility with CMake < 3.5 has been removed from CMake.`