### PR TITLE
Fix compiler->createSourceManager build

### DIFF
--- a/opencl_clang.cpp
+++ b/opencl_clang.cpp
@@ -237,7 +237,7 @@ Compile(const char *pszProgramSource, const char **pInputHeaders,
 
       compiler->setVirtualFileSystem(std::move(OverlayFS));
       compiler->createFileManager();
-      compiler->createSourceManager(compiler->getFileManager());
+      compiler->createSourceManager();
 
       // Create compiler invocation from user args before trickering with it
       clang::CompilerInvocation::CreateFromArgs(compiler->getInvocation(),


### PR DESCRIPTION
`FileManager` parameter is removed in
https://github.com/llvm/llvm-project/commit/b86ddae