### PR TITLE
[LLVM 17] Bring missing LLVM 16 patches to LLVM 17

### DIFF
--- a/patches/0006-Remove-__IMAGE_SUPPORT__-macro-for-SPIR.patch
+++ b/patches/0006-Remove-__IMAGE_SUPPORT__-macro-for-SPIR.patch
@@ -1,0 +1,54 @@
+From 1ca45b5f5725a447ded14c0096df39f2751c4e9a Mon Sep 17 00:00:00 2001
+From: Haonan Yang <haonan.yang@intel.com>
+Date: Fri, 25 Feb 2022 10:36:57 +0800
+Subject: [PATCH] Remove __IMAGE_SUPPORT__ macro for SPIR
+
+Signed-off-by: Haonan Yang <haonan.yang@intel.com>
+
+diff --git a/clang/lib/Frontend/InitPreprocessor.cpp b/clang/lib/Frontend/InitPreprocessor.cpp
+index 208c6a8db159..33c8409eaf12 100644
+--- a/clang/lib/Frontend/InitPreprocessor.cpp
++++ b/clang/lib/Frontend/InitPreprocessor.cpp
+@@ -1288,9 +1288,6 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
+   // OpenCL definitions.
+   if (LangOpts.OpenCL) {
+     InitializeOpenCLFeatureTestMacros(TI, LangOpts, Builder);
+-
+-    if (TI.getTriple().isSPIR() || TI.getTriple().isSPIRV())
+-      Builder.defineMacro("__IMAGE_SUPPORT__");
+   }
+ 
+   if (TI.hasInt128Type() && LangOpts.CPlusPlus && LangOpts.GNUMode) {
+diff --git a/clang/test/Preprocessor/predefined-macros.c b/clang/test/Preprocessor/predefined-macros.c
+index d77b699674af..4dd02c3cfde4 100644
+--- a/clang/test/Preprocessor/predefined-macros.c
++++ b/clang/test/Preprocessor/predefined-macros.c
+@@ -210,28 +210,24 @@
+ 
+ // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spir-unknown-unknown \
+ // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIR
+-// CHECK-SPIR-DAG: #define __IMAGE_SUPPORT__ 1
+ // CHECK-SPIR-DAG: #define __SPIR__ 1
+ // CHECK-SPIR-DAG: #define __SPIR32__ 1
+ // CHECK-SPIR-NOT: #define __SPIR64__ 1
+ 
+ // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spir64-unknown-unknown \
+ // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIR64
+-// CHECK-SPIR64-DAG: #define __IMAGE_SUPPORT__ 1
+ // CHECK-SPIR64-DAG: #define __SPIR__ 1
+ // CHECK-SPIR64-DAG: #define __SPIR64__ 1
+ // CHECK-SPIR64-NOT: #define __SPIR32__ 1
+ 
+ // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spirv32-unknown-unknown \
+ // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIRV32
+-// CHECK-SPIRV32-DAG: #define __IMAGE_SUPPORT__ 1
+ // CHECK-SPIRV32-DAG: #define __SPIRV__ 1
+ // CHECK-SPIRV32-DAG: #define __SPIRV32__ 1
+ // CHECK-SPIRV32-NOT: #define __SPIRV64__ 1
+ 
+ // RUN: %clang_cc1 %s -E -dM -o - -x cl -triple spirv64-unknown-unknown \
+ // RUN:   | FileCheck -match-full-lines %s --check-prefix=CHECK-SPIRV64
+-// CHECK-SPIRV64-DAG: #define __IMAGE_SUPPORT__ 1
+ // CHECK-SPIRV64-DAG: #define __SPIRV__ 1
+ // CHECK-SPIRV64-DAG: #define __SPIRV64__ 1
+ // CHECK-SPIRV64-NOT: #define __SPIRV32__ 1

--- a/patches/0007-OpenCL-Allow-undefining-header-only-macros.patch
+++ b/patches/0007-OpenCL-Allow-undefining-header-only-macros.patch
@@ -1,0 +1,67 @@
+From a60b8f468119065f8a6cb4a16598263cb00de0b5 Mon Sep 17 00:00:00 2001
+From: Sven van Haastregt <sven.vanhaastregt@arm.com>
+Date: Mon, 16 Jan 2023 11:32:12 +0000
+Subject: [PATCH] [OpenCL] Allow undefining header-only features
+
+`opencl-c-base.h` always defines 5 particular feature macros for
+SPIR-V, making it impossible to disable those features.
+
+To allow disabling any of those features, let the header recognize
+`__undef_<feature>` macros.  The user can then pass the
+`-D__undef_<feature>` flag on the command line to disable a specific
+feature.  The __undef macro could potentially also be set from
+`-cl-ext=-feature`, but for now only change the header and only
+provide __undef macros for the 5 features that are always enabled in
+`opencl-c-base.h`.
+
+Differential Revision: https://reviews.llvm.org/D141297
+
+diff --git a/clang/lib/Headers/opencl-c-base.h b/clang/lib/Headers/opencl-c-base.h
+index fad2f9c0272b..84a2d834aa3c 100644
+--- a/clang/lib/Headers/opencl-c-base.h
++++ b/clang/lib/Headers/opencl-c-base.h
+@@ -93,6 +93,24 @@
+ #undef __opencl_c_read_write_images
+ #endif
+ 
++// Undefine any feature macros that have been explicitly disabled using
++// an __undef_<feature> macro.
++#ifdef __undef___opencl_c_work_group_collective_functions
++#undef __opencl_c_work_group_collective_functions
++#endif
++#ifdef __undef___opencl_c_atomic_order_seq_cst
++#undef __opencl_c_atomic_order_seq_cst
++#endif
++#ifdef __undef___opencl_c_atomic_scope_device
++#undef __opencl_c_atomic_scope_device
++#endif
++#ifdef __undef___opencl_c_atomic_scope_all_devices
++#undef __opencl_c_atomic_scope_all_devices
++#endif
++#ifdef __undef___opencl_c_read_write_images
++#undef __opencl_c_read_write_images
++#endif
++
+ #endif // (__OPENCL_CPP_VERSION__ == 202100 || __OPENCL_C_VERSION__ == 300)
+ 
+ #if !defined(__opencl_c_generic_address_space)
+diff --git a/clang/test/SemaOpenCL/features.cl b/clang/test/SemaOpenCL/features.cl
+index 3f59b4ea3b5a..7006fb5d181a 100644
+--- a/clang/test/SemaOpenCL/features.cl
++++ b/clang/test/SemaOpenCL/features.cl
+@@ -35,6 +35,15 @@
+ // RUN:    -D__undef___opencl_c_read_write_images=1 \
+ // RUN:   | FileCheck %s --check-prefix=NO-HEADERONLY-FEATURES
+ 
++// For OpenCL C 3.0, header-only features can be disabled using macros.
++// RUN: %clang_cc1 -triple spir-unknown-unknown %s -E -dM -o - -x cl -cl-std=CL3.0 -fdeclare-opencl-builtins -finclude-default-header \
++// RUN:    -D__undef___opencl_c_work_group_collective_functions=1 \
++// RUN:    -D__undef___opencl_c_atomic_order_seq_cst=1 \
++// RUN:    -D__undef___opencl_c_atomic_scope_device=1 \
++// RUN:    -D__undef___opencl_c_atomic_scope_all_devices=1 \
++// RUN:    -D__undef___opencl_c_read_write_images=1 \
++// RUN:   | FileCheck %s --check-prefix=NO-HEADERONLY-FEATURES
++
+ // Note that __opencl_c_int64 is always defined assuming
+ // always compiling for FULL OpenCL profile
+ 

--- a/patches/0008-Enable-use-of-GNU-C-extension.patch
+++ b/patches/0008-Enable-use-of-GNU-C-extension.patch
@@ -1,0 +1,37 @@
+From 62267fec4a0d74472bc64695597f2477cc8c11df Mon Sep 17 00:00:00 2001
+From: FirstName LastName <your@email.com>
+Date: Wed, 5 Apr 2023 17:02:38 +0200
+Subject: [PATCH] Enable use of GNU C extension - const statement expression as array size
+
+This patch partially reverts the commit:
+llvm/llvm-project@6781fee
+
+For backward compatibility, we still need to support the
+expressions like:
+```
+const int size = ({ false; }) ? 0 : 1;
+float array[size];
+```
+https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html
+
+---
+ clang/lib/Sema/SemaType.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/clang/lib/Sema/SemaType.cpp b/clang/lib/Sema/SemaType.cpp
+index ab47e9f03..8cb26be44 100644
+--- a/clang/lib/Sema/SemaType.cpp
++++ b/clang/lib/Sema/SemaType.cpp
+@@ -2330,7 +2330,8 @@ static ExprResult checkArraySize(Sema &S, Expr *&ArraySize,
+   } Diagnoser(VLADiag, VLAIsError);
+ 
+   ExprResult R =
+-      S.VerifyIntegerConstantExpression(ArraySize, &SizeVal, Diagnoser);
++      S.VerifyIntegerConstantExpression(ArraySize, &SizeVal, Diagnoser,
++      S.LangOpts.OpenCL ? Sema::AllowFold : Sema::NoFold);
+   if (Diagnoser.IsVLA)
+     return ExprResult();
+   return R;
+-- 
+2.34.1
+

--- a/patches/0009-OpenCL-Add-cl_khr_kernel_clock-builtins-91950.patch
+++ b/patches/0009-OpenCL-Add-cl_khr_kernel_clock-builtins-91950.patch
@@ -1,0 +1,80 @@
+From da6a0b7af29a222b2e16a10155b49d4fafe967f3 Mon Sep 17 00:00:00 2001
+From: Sven van Haastregt <sven.vanhaastregt@arm.com>
+Date: Mon, 20 May 2024 09:37:53 +0200
+Subject: [PATCH] [OpenCL] Add cl_khr_kernel_clock builtins (#91950)
+
+---
+ clang/lib/Headers/opencl-c-base.h |  4 ++++
+ clang/lib/Headers/opencl-c.h      | 15 +++++++++++++++
+ clang/lib/Sema/OpenCLBuiltins.td  | 14 ++++++++++++++
+ 3 files changed, 33 insertions(+)
+
+diff --git a/clang/lib/Headers/opencl-c-base.h b/clang/lib/Headers/opencl-c-base.h
+index 2494f6213fc5..786678b9d8a7 100644
+--- a/clang/lib/Headers/opencl-c-base.h
++++ b/clang/lib/Headers/opencl-c-base.h
+@@ -46,6 +46,10 @@
+ #define __opencl_c_ext_fp32_global_atomic_min_max 1
+ #define __opencl_c_ext_fp32_local_atomic_min_max 1
+ #define __opencl_c_ext_image_raw10_raw12 1
++#define cl_khr_kernel_clock 1
++#define __opencl_c_kernel_clock_scope_device 1
++#define __opencl_c_kernel_clock_scope_work_group 1
++#define __opencl_c_kernel_clock_scope_sub_group 1
+ 
+ #endif // defined(__SPIR__) || defined(__SPIRV__)
+ #endif // (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
+diff --git a/clang/lib/Headers/opencl-c.h b/clang/lib/Headers/opencl-c.h
+index 288bb18bc654..20719b74b6b8 100644
+--- a/clang/lib/Headers/opencl-c.h
++++ b/clang/lib/Headers/opencl-c.h
+@@ -17314,6 +17314,21 @@ half __ovld __conv sub_group_clustered_rotate(half, int, uint);
+ #endif // cl_khr_fp16
+ #endif // cl_khr_subgroup_rotate
+ 
++#if defined(cl_khr_kernel_clock)
++#if defined(__opencl_c_kernel_clock_scope_device)
++ulong __ovld clock_read_device();
++uint2 __ovld clock_read_hilo_device();
++#endif // __opencl_c_kernel_clock_scope_device
++#if defined(__opencl_c_kernel_clock_scope_work_group)
++ulong __ovld clock_read_work_group();
++uint2 __ovld clock_read_hilo_work_group();
++#endif // __opencl_c_kernel_clock_scope_work_group
++#if defined(__opencl_c_kernel_clock_scope_sub_group)
++ulong __ovld clock_read_sub_group();
++uint2 __ovld clock_read_hilo_sub_group();
++#endif // __opencl_c_kernel_clock_scope_sub_group
++#endif // cl_khr_kernel_clock
++
+ #if defined(cl_intel_subgroups)
+ // Intel-Specific Sub Group Functions
+ float   __ovld __conv intel_sub_group_shuffle( float , uint );
+diff --git a/clang/lib/Sema/OpenCLBuiltins.td b/clang/lib/Sema/OpenCLBuiltins.td
+index a7bdfe20b982..4da61429fcce 100644
+--- a/clang/lib/Sema/OpenCLBuiltins.td
++++ b/clang/lib/Sema/OpenCLBuiltins.td
+@@ -1852,6 +1852,20 @@ let Extension = FunctionExtension<"cl_khr_subgroup_rotate"> in {
+   def : Builtin<"sub_group_clustered_rotate", [AGenType1, AGenType1, Int, UInt], Attr.Convergent>;
+ }
+ 
++// cl_khr_kernel_clock
++let Extension = FunctionExtension<"cl_khr_kernel_clock __opencl_c_kernel_clock_scope_device"> in {
++  def : Builtin<"clock_read_device", [ULong]>;
++  def : Builtin<"clock_read_hilo_device", [VectorType<UInt, 2>]>;
++}
++let Extension = FunctionExtension<"cl_khr_kernel_clock __opencl_c_kernel_clock_scope_work_group"> in {
++  def : Builtin<"clock_read_work_group", [ULong]>;
++  def : Builtin<"clock_read_hilo_work_group", [VectorType<UInt, 2>]>;
++}
++let Extension = FunctionExtension<"cl_khr_kernel_clock __opencl_c_kernel_clock_scope_sub_group"> in {
++  def : Builtin<"clock_read_sub_group", [ULong]>;
++  def : Builtin<"clock_read_hilo_sub_group", [VectorType<UInt, 2>]>;
++}
++
+ //--------------------------------------------------------------------
+ // Arm extensions.
+ let Extension = ArmIntegerDotProductInt8 in {
+-- 
+2.39.1
+


### PR DESCRIPTION
This PR adds missing patches from https://github.com/intel/opencl-clang/tree/ocl-open-160/patches/clang