### PR TITLE
[Backport to 14] Fix SPIRV-LLVM-Translator header file path in out-of-tree build (#650)

### DIFF
--- a/options.h
+++ b/options.h
@@ -29,6 +29,12 @@ Copyright (c) Intel Corporation (2009-2017).
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/Option.h"
 
+#ifdef USE_PREBUILT_LLVM
+#include "LLVMSPIRVLib/LLVMSPIRVOpts.h"
+#else // USE_PREBUILT_LLVM
+#include "LLVMSPIRVOpts.h"
+#endif // USE_PREBUILT_LLVM
+
 #include <list>
 
 enum COMPILE_OPT_ID {

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -67,7 +67,11 @@ static int parseSPVExtOption(
 #define _STRINGIFY(X) #X
 #define STRINGIFY(X) _STRINGIFY(X)
 #define EXT(X) ExtensionNamesMap[STRINGIFY(X)] = SPIRV::ExtensionID::X;
+#ifdef USE_PREBUILT_LLVM
+#include "LLVMSPIRVLib/LLVMSPIRVExtensions.inc"
+#else // USE_PREBUILT_LLVM
 #include "LLVMSPIRVExtensions.inc"
+#endif // USE_PREBUILT_LLVM
 #undef EXT
 #undef STRINGIFY
 #undef _STRINGIFY


### PR DESCRIPTION
Prepend SPIRV-LLVM-Translator header file path with LLVMSPIRVLib

Resolves #646

(cherry picked from commit ec4a45bb242983e4ce9fc54219da994125bf712e)