### PR TITLE
[CI] Upgrade actions/checkout version to v6.0.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,12 +56,12 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
 
       - name: Checkout opencl-clang sources for action files
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
 
       - name: Checkout SPIRV-LLVM-Translator sources
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: KhronosGroup/SPIRV-LLVM-Translator
           path: SPIRV-LLVM-Translator

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,12 +56,12 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
 
       - name: Checkout opencl-clang sources for action files
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
         with:
           ref: ${{ github.ref }}
 
       - name: Checkout SPIRV-LLVM-Translator sources
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
         with:
           repository: KhronosGroup/SPIRV-LLVM-Translator
           path: SPIRV-LLVM-Translator

--- a/.github/workflows/on-demand-verification.yml
+++ b/.github/workflows/on-demand-verification.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files availabilty
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang

--- a/.github/workflows/on-demand-verification.yml
+++ b/.github/workflows/on-demand-verification.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files availabilty
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang

--- a/.github/workflows/on-push-verification-in-tree.yml
+++ b/.github/workflows/on-push-verification-in-tree.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang

--- a/.github/workflows/on-push-verification-in-tree.yml
+++ b/.github/workflows/on-push-verification-in-tree.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang

--- a/.github/workflows/on-push-verification-out-of-tree.yml
+++ b/.github/workflows/on-push-verification-out-of-tree.yml
@@ -55,7 +55,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
 
       - name: Checkout SPIRV-LLVM-Translator sources
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: KhronosGroup/SPIRV-LLVM-Translator
           path: SPIRV-LLVM-Translator
@@ -74,7 +74,7 @@ jobs:
           echo "spirv_translator_install_dir=${builddir}/install" >> $GITHUB_ENV
 
       - name: Checkout opencl-clang sources
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: opencl-clang
           ref: ${{ github.ref }}

--- a/.github/workflows/on-push-verification-out-of-tree.yml
+++ b/.github/workflows/on-push-verification-out-of-tree.yml
@@ -55,7 +55,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
 
       - name: Checkout SPIRV-LLVM-Translator sources
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
         with:
           repository: KhronosGroup/SPIRV-LLVM-Translator
           path: SPIRV-LLVM-Translator
@@ -74,7 +74,7 @@ jobs:
           echo "spirv_translator_install_dir=${builddir}/install" >> $GITHUB_ENV
 
       - name: Checkout opencl-clang sources
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
         with:
           path: opencl-clang
           ref: ${{ github.ref }}

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -17,7 +17,7 @@ jobs:
       branches_json: ${{steps.release_branches.outputs.branches_json}}
     steps:
       - name: Checkout
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
             fetch-depth: 0
       - name: Get latest llvm_release branch
@@ -49,7 +49,7 @@ jobs:
       matrix: ${{fromJson(needs.setup.outputs.branches_json)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
             ref: ${{ matrix.branch }}
             fetch-depth: 0

--- a/.github/workflows/patch-release.yml
+++ b/.github/workflows/patch-release.yml
@@ -17,7 +17,7 @@ jobs:
       branches_json: ${{steps.release_branches.outputs.branches_json}}
     steps:
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
         with:
             fetch-depth: 0
       - name: Get latest llvm_release branch
@@ -49,7 +49,7 @@ jobs:
       matrix: ${{fromJson(needs.setup.outputs.branches_json)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
         with:
             ref: ${{ matrix.branch }}
             fetch-depth: 0

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files availabilty
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang
@@ -39,7 +39,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files availabilty
-        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang

--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files availabilty
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang
@@ -39,7 +39,7 @@ jobs:
     steps:
 
       - name: Checkout opencl-clang sources for action files availabilty
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@4363294c730e200388a1005a761e5df15e714652 # v6.0.2
 
       - name: Run build-opencl-clang action
         uses: ./.github/actions/build-opencl-clang


### PR DESCRIPTION
"Dependabot failed to create a pull request", so upgrade manually.