### PR TITLE
Fix apply_patches in CMake to work with two directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,14 +165,13 @@ if(NOT USE_PREBUILT_LLVM)
     set(SPIRV_BASE_REVISION llvm_release_170)
     set(TARGET_BRANCH "ocl-open-170")
     get_filename_component(LLVM_MONOREPO_DIR ${LLVM_SOURCE_DIR} DIRECTORY)
+    set(LLVM_PATCHES_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+                          ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang)
+
    if(APPLY_PATCHES)
       message(STATUS "APPLY_PATCHES is enabled.")
       apply_patches(${LLVM_MONOREPO_DIR}
-                    ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
-                    ${LLVM_BASE_REVISION}
-                    ${TARGET_BRANCH})
-      apply_patches(${LLVM_MONOREPO_DIR}
-                    ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang
+                    "${LLVM_PATCHES_DIRS}"
                     ${LLVM_BASE_REVISION}
                     ${TARGET_BRANCH})
       apply_patches(${SPIRV_SOURCE_DIR}

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -83,13 +83,18 @@ endfunction()
 
 #
 # Creates `target_branch` starting at the `base_revision` in the `repo_dir`.
-# Then all patches from the `patches_dir` are committed to the `target_branch`.
+# Then all patches from the `patches_dirs` are committed to the `target_branch`.
+# `patches_dirs` can be a single directory or a semicolon-separated list.
 # Does nothing if the `target_branch` is already checked out in the `repo_dir`.
 #
-function(apply_patches repo_dir patches_dir base_revision target_branch)
-    file(GLOB patches ${patches_dir}/*.patch)
+function(apply_patches repo_dir patches_dirs base_revision target_branch)
+    set(patches)
+    foreach(dir ${patches_dirs})
+        file(GLOB dir_patches ${dir}/*.patch)
+        list(APPEND patches ${dir_patches})
+    endforeach()
     if(NOT patches)
-        message(STATUS "[OPENCL-CLANG] No patches in ${patches_dir}")
+        message(STATUS "[OPENCL-CLANG] No patches in ${patches_dirs}")
         return()
     endif()
 


### PR DESCRIPTION
This reverts recent change that split apply_patches into two calls.
Then it fixes apply_patches implementation to properly apply patches
from multiple direcotires.