### PR TITLE
[ocl-open-180] Add static to OnceFlag in OpenCLClangInitialize (#681)

### DIFF
--- a/opencl_clang.cpp
+++ b/opencl_clang.cpp
@@ -87,7 +87,7 @@ void OpenCLClangInitialize() {
   // multi-threaded envirounment and LLVM libraries user is expected call
   // llvm_shutdown before static object are destroyed, so we use atexit to
   // satisfy this requirement.
-  llvm::once_flag OnceFlag;
+  static llvm::once_flag OnceFlag;
   llvm::call_once(OnceFlag, []() { atexit(OpenCLClangTerminate); });
 }
 


### PR DESCRIPTION
Without static, every call to OpenCLClangInitialize registers a new atexit handler, which could cause thread-safety and resource issues.

(cherry picked from commit df38bde9fc58b5c465b5273cb6d4def5f897ef40)