### PR TITLE
Fix race condition on concurrent write to s_progID

### DIFF
--- a/options.h
+++ b/options.h
@@ -151,7 +151,6 @@ public:
 
 private:
   std::string m_opencl_ver;
-  static int s_progID;
 };
 
 ///

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -58,8 +58,6 @@ static constexpr OptTable::Info ClangOptionsInfoTable[] = {
 OpenCLCompileOptTable::OpenCLCompileOptTable()
     : OpenCLOptTable(ClangOptionsInfoTable) {}
 
-int EffectiveOptionsFilter::s_progID = 1;
-
 // This code was adopted from the SPIRV-LLVM-Translator repository.
 static int parseSPVExtOption(
     llvm::StringRef SPVExt,
@@ -139,7 +137,7 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
   bool isCpp = false;
   bool fp64Enabled = false;
   std::string szTriple;
-  std::string sourceName(llvm::Twine(s_progID++).str());
+  std::string sourceName("input.cl");
 
   for (OpenCLArgList::const_iterator it = args.begin(), ie = args.end();
        it != ie; ++it) {


### PR DESCRIPTION
There was no lock to guard s_progID increment.

Delete s_progID and hardcode sourceName as `input.cl`. sourceName only serve for diagnose purpose and opencl-clang already provides `-s` command line option to specify the sourceName.

For best diagnose, user should use `-s` command line option.