### PR TITLE
Revert 704f1fd and use std::atomic<int> for s_progID

### DIFF
--- a/options.h
+++ b/options.h
@@ -34,6 +34,7 @@ Copyright (c) Intel Corporation (2009-2017).
 #include "LLVMSPIRVOpts.h"
 #endif // USE_PREBUILT_LLVM
 
+#include <atomic>
 #include <list>
 
 enum COMPILE_OPT_ID {
@@ -151,6 +152,7 @@ public:
 
 private:
   std::string m_opencl_ver;
+  static std::atomic<int> s_progID;
 };
 
 ///

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -58,6 +58,8 @@ static constexpr OptTable::Info ClangOptionsInfoTable[] = {
 OpenCLCompileOptTable::OpenCLCompileOptTable()
     : OpenCLOptTable(ClangOptionsInfoTable) {}
 
+std::atomic<int> EffectiveOptionsFilter::s_progID{1};
+
 // This code was adopted from the SPIRV-LLVM-Translator repository.
 static int parseSPVExtOption(
     llvm::StringRef SPVExt,
@@ -137,7 +139,7 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
   bool isCpp = false;
   bool fp64Enabled = false;
   std::string szTriple;
-  std::string sourceName("input.cl");
+  std::string sourceName(llvm::Twine(s_progID++).str());
 
   for (OpenCLArgList::const_iterator it = args.begin(), ie = args.end();
        it != ie; ++it) {


### PR DESCRIPTION
Revert 704f1fd since `input.cl` looks like a real file name and can be confusing when present in diagnose/debug info.
This PR is marginally better than 704f1fd.