### PR TITLE
[ocl-open-160] Fix race condition on concurrent write to s_progID

### DIFF
--- a/options.h
+++ b/options.h
@@ -34,6 +34,7 @@ Copyright (c) Intel Corporation (2009-2017).
 #include "LLVMSPIRVOpts.h"
 #endif // USE_PREBUILT_LLVM
 
+#include <atomic>
 #include <list>
 
 enum COMPILE_OPT_ID {
@@ -142,7 +143,7 @@ public:
 
 private:
   std::string m_opencl_ver;
-  static int s_progID;
+  static std::atomic<int> s_progID;
 };
 
 ///

--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -61,7 +61,7 @@ static constexpr OptTable::Info ClangOptionsInfoTable[] = {
 OpenCLCompileOptTable::OpenCLCompileOptTable()
     : OpenCLOptTable(ClangOptionsInfoTable) {}
 
-int EffectiveOptionsFilter::s_progID = 1;
+std::atomic<int> EffectiveOptionsFilter::s_progID{1};
 
 // This code was adopted from the SPIRV-LLVM-Translator repository.
 static int parseSPVExtOption(


### PR DESCRIPTION
use std::atomic<int> for s_progID.

(cherry picked from commit 704f1fd7d80dd06305320081809f0af9612e4c7f) (cherry picked from commit 40fcf8ecb0aa2b2984672eee6850c482170bf3a3)