### PR TITLE
Fix space escape in `--cl-options="-s /path\ with\ spaces/kernel.cl"`

### DIFF
--- a/options.h
+++ b/options.h
@@ -247,8 +247,12 @@ void quoted_tokenize(OutIt dest, llvm::StringRef str, llvm::StringRef delims,
   while (ptr < end) {
     char c = str[ptr];
     if (c == escape) {
-      tok += c;
-      is_escaped = is_escaped ? false : true;
+      if (is_escaped) {
+        tok += c;
+        is_escaped = false;
+      } else {
+        is_escaped = true;
+      }
     } else if (c == quote) {
       if (is_escaped) {
         tok += c;
@@ -257,9 +261,9 @@ void quoted_tokenize(OutIt dest, llvm::StringRef str, llvm::StringRef delims,
         in_quote = in_quote ? false : true;
       }
     } else if (delims.find(c) != llvm::StringRef::npos) {
-      is_escaped = false;
-      if (in_quote) {
+      if (is_escaped || in_quote) {
         tok += c;
+        is_escaped = false;
       } else {
         *(dest++) = tok;
         tok.clear();


### PR DESCRIPTION
Fixes test Manual/testsuite/s-option.cl in #715.

Bug: delimiter branch ignores is_escaped, so \  (backslash-space) breaks the token instead of inserting a literal space.

Two fixes:
- escape char: don't add to tok; set is_escaped=true, or if already escaped emit literal \ and clear flag.
- Delimiter: check is_escaped (not just in_quote) before breaking token; clear is_escaped after consuming.

Assisted-by: Claude