### PR TITLE
Improve -cl-ext parsing: ignore trailing comma

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -372,6 +372,8 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
     llvm::SmallVector<llvm::StringRef, 32> parsedExt;
     clExtRef.split(parsedExt, ',');
     for (auto &ext : parsedExt) {
+      if (ext.empty())
+        continue;
       char sign = ext.front();
       bool enabled = sign != '-';
       llvm::StringRef extName = ext;


### PR DESCRIPTION
This is exposed by a LIT test (in #715) that has trailing comma in -cl-ext option.