### PR TITLE
Fix __FINITE_MATH_ONLY__ double defined

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -180,8 +180,6 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
     }
     case OPT_COMPILE_cl_finite_math_only:
       effectiveArgs.push_back((*it)->getAsString(args));
-      effectiveArgs.push_back("-D");
-      effectiveArgs.push_back("__FINITE_MATH_ONLY__=1");
       break;
     case OPT_COMPILE_cl_fast_relaxed_math:
       effectiveArgs.push_back((*it)->getAsString(args));


### PR DESCRIPTION
When -cl-finite-math-only option is specified, clang defines the macro. opencl-clang shouldn't re-define it.

Fixes test c99_kernels/testsuite/ocl/AppKernels/Bionic/Collatz/program_1_0.cl in #715.