### PR TITLE
[ocl-open-220] Restore Windows resource file configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,37 @@ add_llvm_library(${TARGET_NAME} SHARED
   )
 
 if (WIN32)
+    # Configure version resource file on Windows.
+    # windows_resource_file should be defined by add_llvm_library and should
+    # contain the full path to a .rc file.
+    # It also might not be defined if this library is built out-of-tree:
+    # let's use our copy of the .rc file from the LLVM source tree in that case.
+    if (NOT DEFINED windows_resource_file)
+        set(windows_resource_file windows_resource_file.rc)
+    endif(NOT DEFINED windows_resource_file)
+
+    set(RC_CHAR_TM "\\231")
+    set(RC_CHAR_R "\\256")
+
+    set(RC_FILE_VERSION "${PRODUCT_VER_MAJOR}.${PRODUCT_VER_MINOR}.${LLVM_VER_MAJOR}.${LLVM_VER_MINOR}")
+    set(RC_PRODUCT_NAME "Intel${RC_CHAR_R} Front-end Library for OpenCL${RC_CHAR_TM} software")
+
+    # Adjust content of the resource file by specifying compile definitions
+    set_property(SOURCE ${windows_resource_file}
+        PROPERTY COMPILE_DEFINITIONS
+            "RC_VERSION_FIELD_1=${PRODUCT_VER_MAJOR}"
+            "RC_VERSION_FIELD_2=${PRODUCT_VER_MINOR}"
+            "RC_VERSION_FIELD_3=${LLVM_VER_MAJOR}"
+            "RC_VERSION_FIELD_4=${LLVM_VER_MINOR}"
+            "RC_COMPANY_NAME=\"Intel Corporation\""
+            "RC_FILE_DESCRIPTION=\"${RC_PRODUCT_NAME}\""
+            "RC_FILE_VERSION=\"${RC_FILE_VERSION}\""
+            "RC_INTERNAL_NAME=\"${TARGET_NAME}\""
+            "RC_ORIGINAL_FILENAME=\"${TARGET_NAME}.dll\""
+            "RC_PRODUCT_NAME=\"${RC_PRODUCT_NAME}\""
+            "RC_PRODUCT_VERSION=\"${RC_FILE_VERSION}\""
+            "RC_COPYRIGHT=\"Copyright (C) 2018 Intel Corporation\"")
+
     # Enable compiler generation of Control Flow Guard security checks.
     target_compile_options(${TARGET_NAME} PUBLIC "/guard:cf")
     set_property(TARGET ${TARGET_NAME} APPEND PROPERTY

--- a/windows_resource_file.rc
+++ b/windows_resource_file.rc
@@ -1,0 +1,91 @@
+// This file was copied from LLVM_SOURCE_DIR/resources/windows_version_resource.rc
+
+// Microsoft Visual C++ resource script for embedding version information.
+// The format is described at:
+//   http://msdn.microsoft.com/en-gb/library/windows/desktop/aa380599(v=vs.85).aspx
+// The VERSIONINFO resource is described at:
+//   https://msdn.microsoft.com/en-gb/library/windows/desktop/aa381058(v=vs.85).aspx
+
+
+// Default values for required fields.
+
+#ifndef RC_VERSION_FIELD_1
+#define RC_VERSION_FIELD_1 0
+#endif
+
+#ifndef RC_VERSION_FIELD_2
+#define RC_VERSION_FIELD_2 0
+#endif
+
+#ifndef RC_VERSION_FIELD_3
+#define RC_VERSION_FIELD_3 0
+#endif
+
+#ifndef RC_VERSION_FIELD_4
+#define RC_VERSION_FIELD_4 0
+#endif
+
+#ifndef RC_COMPANY_NAME
+#define RC_COMPANY_NAME ""
+#endif
+
+#ifndef RC_FILE_DESCRIPTION
+#define RC_FILE_DESCRIPTION ""
+#endif
+
+#ifndef RC_FILE_VERSION
+#define RC_FILE_VERSION ""
+#endif
+
+#ifndef RC_INTERNAL_NAME
+#define RC_INTERNAL_NAME ""
+#endif
+
+#ifndef RC_ORIGINAL_FILENAME
+#define RC_ORIGINAL_FILENAME ""
+#endif
+
+#ifndef RC_PRODUCT_NAME
+#define RC_PRODUCT_NAME ""
+#endif
+
+#ifndef RC_PRODUCT_VERSION
+#define RC_PRODUCT_VERSION ""
+#endif
+
+
+1 VERSIONINFO
+FILEVERSION RC_VERSION_FIELD_1,RC_VERSION_FIELD_2,RC_VERSION_FIELD_3,RC_VERSION_FIELD_4
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      // Required strings
+      VALUE "CompanyName", RC_COMPANY_NAME
+      VALUE "FileDescription", RC_FILE_DESCRIPTION
+      VALUE "FileVersion", RC_FILE_VERSION
+      VALUE "InternalName", RC_INTERNAL_NAME
+      VALUE "OriginalFilename", RC_ORIGINAL_FILENAME
+      VALUE "ProductName", RC_PRODUCT_NAME
+      VALUE "ProductVersion", RC_PRODUCT_VERSION
+
+      // Optional strings
+#ifdef RC_COMMENTS
+        VALUE "Comments", RC_COMMENTS
+#endif
+
+#ifdef RC_COPYRIGHT
+        VALUE "LegalCopyright", RC_COPYRIGHT
+#endif
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    // The translation must correspond to the above BLOCK inside StringFileInfo
+    // langID     0x0409  U.S. English
+    // charsetID  0x04B0  Unicode
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END


### PR DESCRIPTION
The library lost its Version Information fields, leaving LLVM's defaults - empty CompanyName and LegalCopyright, "LLVM" ProductName and different ProductVersion/FileVersion.

Commit 743bd15 swapped `add_llvm_library` for `add_library` and deleted Windows resource file configuration that filled in the Intel version strings. That commit was partially reverted in e047ae6, but the mechanism wasn't reintroduced - `add_llvm_library` has been attaching LLVM's default .rc file ever since.

This commit restores resource file configuration in CMakeLists.txt and restores windows_resource_file.rc as a fallback for out-of-tree builds. The code is copied from ocl-open-140, where the issue isn't present.