### PR TITLE
[ocl-open-150] Error out in CMake if a clang patch fails to apply

### DIFF
--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -144,12 +144,22 @@ function(apply_patches repo_dir patches_dirs base_revision target_branch)
                 execute_process( # Apply the patch
                     COMMAND ${GIT_EXECUTABLE} am --3way --keep-non-patch --ignore-whitespace -C0 ${patch}
                     WORKING_DIRECTORY ${repo_dir}
-                    OUTPUT_VARIABLE patching_log
                     RESULT_VARIABLE ret_apply_patch
+                    OUTPUT_VARIABLE patching_log
+                    ERROR_VARIABLE  patching_err
                 )
-                message(STATUS "[OPENCL-CLANG] Not present - ${patching_log}")
-                if (ret_apply_patch)
-                    break()
+                message(STATUS "[OPENCL-CLANG] Applying ${patch}\n${patching_log}")
+                if(ret_apply_patch)
+                    execute_process( # Abort the half-applied am so the repo is left in a sane state
+                        COMMAND ${GIT_EXECUTABLE} am --abort
+                        WORKING_DIRECTORY ${repo_dir}
+                        OUTPUT_QUIET ERROR_QUIET
+                    )
+                    message(FATAL_ERROR
+                        "[OPENCL-CLANG] Failed to apply patch ${patch}\n"
+                        "git am exit code: ${ret_apply_patch}\n"
+                        "stdout:\n${patching_log}\n"
+                        "stderr:\n${patching_err}")
                 endif()
             endif()
         endforeach(patch)


### PR DESCRIPTION
failed patches were silently ignored

(cherry picked from commit 25fdfd6798d3fd7986180baf9a6d22d01d0a2be3)