### PR TITLE
[ocl-open-220] Fix heap-buffer-overflow in GCRelocateInst::getBasePtr/getDerivedPtr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,9 +160,15 @@ if(NOT USE_PREBUILT_LLVM)
     set(CLANG_BASE_REVISION release/22.x)
     set(SPIRV_BASE_REVISION llvm_release_220)
     set(TARGET_BRANCH ocl-open-220)
+    get_filename_component(LLVM_MONOREPO_DIR ${LLVM_SOURCE_DIR} DIRECTORY)
+    set(LLVM_PATCHES_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/patches/llvm
+                          ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang)
 
-    apply_patches(${CLANG_SOURCE_DIR}
-                  ${CMAKE_CURRENT_SOURCE_DIR}/patches/clang
+    # Apply the LLVM core patches together with the Clang patches to the
+    # monorepo in a single call: apply_patches creates the target branch on its
+    # first invocation, so subsequent calls on the same repository are skipped.
+    apply_patches(${LLVM_MONOREPO_DIR}
+                  "${LLVM_PATCHES_DIRS}"
                   ${CLANG_BASE_REVISION}
                   ${TARGET_BRANCH})
     apply_patches(${SPIRV_SOURCE_DIR}

--- a/cmake/modules/CMakeFunctions.cmake
+++ b/cmake/modules/CMakeFunctions.cmake
@@ -87,7 +87,11 @@ endfunction()
 # Does nothing if the `target_branch` is already checked out in the `repo_dir`.
 #
 function(apply_patches repo_dir patches_dir base_revision target_branch)
-    file(GLOB patches ${patches_dir}/*.patch)
+    set(patches "")
+    foreach(single_patches_dir ${patches_dir})
+        file(GLOB single_dir_patches ${single_patches_dir}/*.patch)
+        list(APPEND patches ${single_dir_patches})
+    endforeach()
     if(NOT patches)
         message(STATUS "[OPENCL-CLANG] No patches in ${patches_dir}")
         return()

--- a/patches/llvm/0001-LLVM-Verifier-Fix-buffer-overflow-when-verifying-gc.patch
+++ b/patches/llvm/0001-LLVM-Verifier-Fix-buffer-overflow-when-verifying-gc.patch
@@ -1,0 +1,85 @@
+From 7bb9626d5ab901e5c1a8e9acbbb1684c982401b4 Mon Sep 17 00:00:00 2001
+From: Tulio Magno Quites Machado Filho <tuliom@redhat.com>
+Date: Fri, 10 Jul 2026 18:45:02 +0000
+Subject: [PATCH] [LLVM][Verifier] Fix buffer overflow when verifying
+ gc.statepoint (#208278)
+
+When a negative base index is passed, the verification detects the
+out-of-bounds value and start printing information that helps to
+identify what caused the error. In order to print all the information,
+it tries to dereference the Base pointer at
+GCRelocateInst::getBasePtr(), causing the buffer overflow. Add a bounds
+check to getBasePTR() and getDerivedPtr() in order to avoid this.
+
+Improve the test in order to validate negative values passed as indexes.
+They're based on the reproducer from issue #199191.
+
+Fixes #199191
+---
+ llvm/lib/IR/AsmWriter.cpp     | 10 ++++++++--
+ llvm/lib/IR/IntrinsicInst.cpp | 26 ++++++++++++++++++++------
+ 2 files changed, 28 insertions(+), 8 deletions(-)
+
+diff --git a/llvm/lib/IR/AsmWriter.cpp b/llvm/lib/IR/AsmWriter.cpp
+--- a/llvm/lib/IR/AsmWriter.cpp
++++ b/llvm/lib/IR/AsmWriter.cpp
+@@ -3993,7 +3993,13 @@ void AssemblyWriter::printGCRelocateComment(const GCRelocateInst &Relocate) {
+ void AssemblyWriter::printGCRelocateComment(const GCRelocateInst &Relocate) {
+   Out << " ; (";
+-  writeOperand(Relocate.getBasePtr(), false);
++  if (Value *BasePtr = Relocate.getBasePtr())
++    writeOperand(BasePtr, false);
++  else
++    Out << "invalid";
+   Out << ", ";
+-  writeOperand(Relocate.getDerivedPtr(), false);
++  if (Value *DerivedPtr = Relocate.getDerivedPtr())
++    writeOperand(DerivedPtr, false);
++  else
++    Out << "invalid";
+   Out << ")";
+ }
+diff --git a/llvm/lib/IR/IntrinsicInst.cpp b/llvm/lib/IR/IntrinsicInst.cpp
+--- a/llvm/lib/IR/IntrinsicInst.cpp
++++ b/llvm/lib/IR/IntrinsicInst.cpp
+@@ -826,21 +826,34 @@ Value *GCRelocateInst::getBasePtr() const {
+ Value *GCRelocateInst::getBasePtr() const {
+   auto Statepoint = getStatepoint();
+   if (isa<UndefValue>(Statepoint))
+     return UndefValue::get(Statepoint->getType());
+-
++  // Handle too few (bundle) arguments to avoid crashes when printing invalid
++  // IR, e.g. in the verifier.
+   auto *GCInst = cast<GCStatepointInst>(Statepoint);
+-  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live))
++  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live)) {
++    if (getBasePtrIndex() > Opt->Inputs.size())
++      return nullptr;
+     return *(Opt->Inputs.begin() + getBasePtrIndex());
++  }
++  if (getBasePtrIndex() > GCInst->arg_size())
++    return nullptr;
+   return *(GCInst->arg_begin() + getBasePtrIndex());
+ }
+ 
+ Value *GCRelocateInst::getDerivedPtr() const {
+   auto *Statepoint = getStatepoint();
+   if (isa<UndefValue>(Statepoint))
+     return UndefValue::get(Statepoint->getType());
+ 
++  // Handle too few (bundle) arguments to avoid crashes when printing invalid
++  // IR, e.g. in the verifier.
+   auto *GCInst = cast<GCStatepointInst>(Statepoint);
+-  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live))
++  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live)) {
++    if (getDerivedPtrIndex() > Opt->Inputs.size())
++      return nullptr;
+     return *(Opt->Inputs.begin() + getDerivedPtrIndex());
++  }
++  if (getDerivedPtrIndex() > GCInst->arg_size())
++    return nullptr;
+   return *(GCInst->arg_begin() + getDerivedPtrIndex());
+ }
+-- 
+2.43.0
+


### PR DESCRIPTION
Enable LLVM-core patching for this branch (apply patches/llvm together with patches/clang to the monorepo, matching ocl-open-14x..18x) and add a backport of llvm/llvm-project 7bb9626d5ab9 (Fixes #199191), so the LLVM statically linked into cclang bounds-checks the gc.relocate base/derived pointer index when built from source. Without it a malformed gc.relocate triggers a heap-buffer-overflow read while the verifier prints the offending instruction.