### PR TITLE
[ocl-open-170] Fix heap-buffer-overflow in GCRelocateInst::getBasePtr/getDerivedPtr

### DIFF
--- a/patches/llvm/0003-LLVM-Verifier-Fix-buffer-overflow-when-verifying-gc.patch
+++ b/patches/llvm/0003-LLVM-Verifier-Fix-buffer-overflow-when-verifying-gc.patch
@@ -1,0 +1,85 @@
+From 7bb9626d5ab901e5c1a8e9acbbb1684c982401b4 Mon Sep 17 00:00:00 2001
+From: Tulio Magno Quites Machado Filho <tuliom@redhat.com>
+Date: Fri, 10 Jul 2026 18:45:02 +0000
+Subject: [PATCH] [LLVM][Verifier] Fix buffer overflow when verifying
+ gc.statepoint (#208278)
+
+When a negative base index is passed, the verification detects the
+out-of-bounds value and start printing information that helps to
+identify what caused the error. In order to print all the information,
+it tries to dereference the Base pointer at
+GCRelocateInst::getBasePtr(), causing the buffer overflow. Add a bounds
+check to getBasePTR() and getDerivedPtr() in order to avoid this.
+
+Improve the test in order to validate negative values passed as indexes.
+They're based on the reproducer from issue #199191.
+
+Fixes #199191
+---
+ llvm/lib/IR/AsmWriter.cpp     | 10 ++++++++--
+ llvm/lib/IR/IntrinsicInst.cpp | 26 ++++++++++++++++++++------
+ 2 files changed, 28 insertions(+), 8 deletions(-)
+
+diff --git a/llvm/lib/IR/AsmWriter.cpp b/llvm/lib/IR/AsmWriter.cpp
+--- a/llvm/lib/IR/AsmWriter.cpp
++++ b/llvm/lib/IR/AsmWriter.cpp
+@@ -3993,7 +3993,13 @@ void AssemblyWriter::printGCRelocateComment(const GCRelocateInst &Relocate) {
+ void AssemblyWriter::printGCRelocateComment(const GCRelocateInst &Relocate) {
+   Out << " ; (";
+-  writeOperand(Relocate.getBasePtr(), false);
++  if (Value *BasePtr = Relocate.getBasePtr())
++    writeOperand(BasePtr, false);
++  else
++    Out << "invalid";
+   Out << ", ";
+-  writeOperand(Relocate.getDerivedPtr(), false);
++  if (Value *DerivedPtr = Relocate.getDerivedPtr())
++    writeOperand(DerivedPtr, false);
++  else
++    Out << "invalid";
+   Out << ")";
+ }
+diff --git a/llvm/lib/IR/IntrinsicInst.cpp b/llvm/lib/IR/IntrinsicInst.cpp
+--- a/llvm/lib/IR/IntrinsicInst.cpp
++++ b/llvm/lib/IR/IntrinsicInst.cpp
+@@ -826,21 +826,34 @@ Value *GCRelocateInst::getBasePtr() const {
+ Value *GCRelocateInst::getBasePtr() const {
+   auto Statepoint = getStatepoint();
+   if (isa<UndefValue>(Statepoint))
+     return UndefValue::get(Statepoint->getType());
+-
++  // Handle too few (bundle) arguments to avoid crashes when printing invalid
++  // IR, e.g. in the verifier.
+   auto *GCInst = cast<GCStatepointInst>(Statepoint);
+-  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live))
++  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live)) {
++    if (getBasePtrIndex() > Opt->Inputs.size())
++      return nullptr;
+     return *(Opt->Inputs.begin() + getBasePtrIndex());
++  }
++  if (getBasePtrIndex() > GCInst->arg_size())
++    return nullptr;
+   return *(GCInst->arg_begin() + getBasePtrIndex());
+ }
+ 
+ Value *GCRelocateInst::getDerivedPtr() const {
+   auto *Statepoint = getStatepoint();
+   if (isa<UndefValue>(Statepoint))
+     return UndefValue::get(Statepoint->getType());
+ 
++  // Handle too few (bundle) arguments to avoid crashes when printing invalid
++  // IR, e.g. in the verifier.
+   auto *GCInst = cast<GCStatepointInst>(Statepoint);
+-  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live))
++  if (auto Opt = GCInst->getOperandBundle(LLVMContext::OB_gc_live)) {
++    if (getDerivedPtrIndex() > Opt->Inputs.size())
++      return nullptr;
+     return *(Opt->Inputs.begin() + getDerivedPtrIndex());
++  }
++  if (getDerivedPtrIndex() > GCInst->arg_size())
++    return nullptr;
+   return *(GCInst->arg_begin() + getDerivedPtrIndex());
+ }
+-- 
+2.43.0
+


### PR DESCRIPTION
Backport of llvm/llvm-project 7bb9626d5ab9 (Fixes #199191) as an opencl-clang LLVM patch, so the LLVM statically linked into cclang bounds-checks the gc.relocate base/derived pointer index. Without it a malformed gc.relocate triggers a heap-buffer-overflow read while the verifier prints the offending instruction.