### PR TITLE
[ocl-open-150] Add tests folder and enable in pre-commit (partial cherry-pick of 5a5b1f9431)

### DIFF
--- a/.github/actions/build-opencl-clang/action.yml
+++ b/.github/actions/build-opencl-clang/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Build type to pass to CMake'
     required: false
     default: Release
+  run_tests:
+    description: 'Run ninja check-opencl-clang after build'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -59,10 +63,17 @@ runs:
           -DLLVM_EXTERNAL_OPENCL_CLANG_SOURCE_DIR=${{ github.workspace }}/llvm-project/opencl-clang        \
           -DCMAKE_BUILD_TYPE=${{ inputs.build_type }}  \
           -DLLVM_TARGETS_TO_BUILD="X86" \
-          -G "Unix Makefiles"
+          -G "Ninja"
 
     - name: Build
       shell: bash
       run: |
         cd build
-        make opencl-clang -j8
+        ninja opencl-clang
+
+    - name: Test
+      if: ${{ inputs.run_tests == 'true' }}
+      shell: bash
+      run: |
+        cd build
+        ninja check-opencl-clang

--- a/.github/workflows/on-push-verification-out-of-tree.yml
+++ b/.github/workflows/on-push-verification-out-of-tree.yml
@@ -2,7 +2,7 @@
 # Running on push & pull_request.
 # ===---
 
-name: Out-of-tree build
+name: Build
 run-name: '${{ github.event_name }}: ${{ github.base_ref }} ${{ github.ref_name }}' # github.base_ref null for 'on: push'
 
 permissions:
@@ -28,7 +28,7 @@ on:
 jobs:
 
   verify_default_branch:
-    name: linux
+    name: Out-of-tree Linux
     # ref_name for 'on: push'
     # base_ref for 'on: pull_request'
     runs-on: ubuntu-24.04

--- a/.github/workflows/on-push-verification.yml
+++ b/.github/workflows/on-push-verification.yml
@@ -1,10 +1,10 @@
 # ===---
 # Running on push & pull_request.
-#   This workflow parses the destination branch
-#   to choose correct dependencies revisions
+#   Builds opencl-clang in-tree and runs ninja check-opencl-clang.
+#   Parses the destination branch to choose correct dependency revisions.
 # ===---
 
-name: In-tree build
+name: In-tree Build and Test
 run-name: '${{ github.event_name }}: ${{ github.base_ref }} ${{ github.ref_name }}' # github.base_ref null for 'on: push'
 
 on:
@@ -51,3 +51,4 @@ jobs:
           ref_llvm: release/${{ steps.check-llvm-version.outputs.llvm_version }}.x
           ref_translator: llvm_release_${{ steps.check-llvm-version.outputs.llvm_version }}0
           ref_opencl-clang: ${{ github.ref }}
+          run_tests: 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,3 +358,8 @@ install(FILES common_clang.h
 SET_LINUX_EXPORTS_FILE( ${TARGET_NAME} common_clang.map )
 
 add_custom_target(deploy DEPENDS install-${TARGET_NAME})
+
+if(LLVM_INCLUDE_TESTS)
+  set(OPENCL_CLANG_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+  add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(LLVM_TOOLS_DIR ${LLVM_TOOLS_BINARY_DIR})
+
+set(OPENCL_CLANG_TEST_DEVICE "DEFAULT" CACHE STRING "Device name for opencl-clang lit tests (section key in ConfExt.ini)")
+
+add_subdirectory(occ-cli)
+
+# Set the depends list as a variable so that it can grow conditionally.
+# NOTE: Sync the substitutions in test/lit.cfg when adding to this list.
+set(OPENCL_CLANG_TEST_DEPENDS
+  FileCheck
+  llvm-dis
+  count
+  not
+  occ-cli
+  ${TARGET_NAME}
+)
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+add_lit_testsuite(check-opencl-clang "Running the OpenCL Clang regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${OPENCL_CLANG_TEST_DEPENDS}
+  )
+set_target_properties(check-opencl-clang PROPERTIES FOLDER "OpenCL-Clang Tests")

--- a/tests/Manual/testsuite/GNU89Inline.cl
+++ b/tests/Manual/testsuite/GNU89Inline.cl
@@ -1,0 +1,8 @@
+// RUN: %occ-cli %s %cfg_path --cl-device=%cl_device --output=%t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+// CHECK: define dso_local spir_func void @a
+
+inline void a() { return; }
+
+void b() { a(); }

--- a/tests/Manual/testsuite/channels.cl
+++ b/tests/Manual/testsuite/channels.cl
@@ -1,0 +1,22 @@
+// RUN: %occ-cli %s %cfg_path --cl-device=%cl_device --output=%t.bc
+// RUN: %occ-cli %s %cfg_path --cl-options="-DUSE_CHANNELS -cl-std=CL2.0" --cl-version=200 --use-channels --cl-device=%cl_device --output=%t.bc
+// XFAIL: *
+
+#ifndef cl_intel_channels
+
+#ifdef USE_CHANNELS
+#error "cl_intel_channels expected to be enabled"
+#endif
+
+__kernel void foo() { int channel = 1; }
+
+#else // cl_intel_channels
+
+#ifndef USE_CHANNELS
+#error "cl_intel_channels should NOT be enabled"
+#endif
+
+#pragma OPENCL EXTENSION cl_intel_channels : enable
+channel int ch;
+__kernel void foo() { int i = read_channel_intel(ch); }
+#endif // cl_intel_channels

--- a/tests/Manual/testsuite/check-cl-no-subgroup-ifp-option.cl
+++ b/tests/Manual/testsuite/check-cl-no-subgroup-ifp-option.cl
@@ -1,0 +1,10 @@
+/*  'testsuite/check-cl-no-subgroup-ifp-option.cl'  */
+
+// RUN: %occ-cli %s --cl-options=-cl-no-subgroup-ifp  %cfg_path --cl-device=%cl_device --output=%t.bc RUN: llvm-dis %t.bc -o - | FileCheck %s
+// XFAIL: *
+
+// buildOptions:
+// CHECK: !opencl.compiler.options = !{![[MDN:[0-9]+]]}
+// CHECK: ![[MDN]] = {{.*}}"-cl-no-subgroup-ifp"
+
+__kernel void ocl_test_kernel() {}

--- a/tests/Manual/testsuite/cl-ext-option.cl
+++ b/tests/Manual/testsuite/cl-ext-option.cl
@@ -1,0 +1,33 @@
+// RUN: %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL1.2" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL2.0" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL1.2" --cl-options-ex="-cl-ext=-all,+cl_khr_fp64" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL2.0" --cl-options-ex="-cl-ext=-all,+cl_khr_fp64" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL3.0" --cl-options-ex="-cl-ext=-all,+cl_khr_fp64,+__opencl_c_fp64,-cl_khr_3d_image_writes,+__opencl_c_images" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL3.1" --cl-options-ex="-cl-ext=-all,+cl_khr_fp64,+__opencl_c_fp64,-cl_khr_3d_image_writes,+__opencl_c_images" --cl-device=%cl_device %cfg_path --output=%t.bc
+
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL1.2" --cl-options-ex="-cl-ext=-cl_khr_fp64" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL2.0" --cl-options-ex="-cl-ext=-cl_khr_fp64" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL3.0" --cl-options-ex="-cl-ext=-cl_khr_fp64,-__opencl_c_fp64,-cl_khr_3d_image_writes" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL3.1" --cl-options-ex="-cl-ext=-cl_khr_fp64,-__opencl_c_fp64,-cl_khr_3d_image_writes" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL1.2" --cl-options-ex="-cl-ext=-all" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL2.0" --cl-options-ex="-cl-ext=-all" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL3.0" --cl-options-ex="-cl-ext=-all" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL3.1" --cl-options-ex="-cl-ext=-all" --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+
+__kernel void
+MyKernel(const float fConstant, const double dConstant,
+         // CHECK: error: use of type 'double' requires [[FP64:cl_khr_fp64( and __opencl_c_fp64)?]] support
+         __global double *pDouble)
+         // CHECK: error: use of type 'double' requires [[FP64]] support
+{
+  float f = fConstant + 1.0;
+  // CHECK: warning: double precision constant requires [[FP64]], casting to single precision
+  double d = fConstant;
+  // CHECK: error: use of type 'double' requires [[FP64]] support
+
+  f = cos(1.0);
+  // CHECK: warning: double precision constant requires [[FP64]], casting to single precision
+
+  f = (double)1.0f;
+  // CHECK: use of type 'double' requires [[FP64]] support
+}

--- a/tests/Manual/testsuite/dbg-line-column.cl
+++ b/tests/Manual/testsuite/dbg-line-column.cl
@@ -1,0 +1,19 @@
+/*  'testsuite/dbg-line-column.cl'  */
+// "-g" option does not generate dwarf column information on Windows.
+// RUN: %occ-cli %s --cl-options="-g" %cfg_path --cl-device=%cl_device --output=%t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+// CHECK: call void @llvm.dbg.declare(metadata ptr %input.addr, metadata ![[#]], metadata !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef)), !dbg ![[LOC:[0-9]+]]
+// Only check there is line and scope information since column information
+// isn't generated on Windows
+// CHECK: ![[LOC]] = !DILocation(line: {{[0-9]+}}, {{.*}}scope: !{{[0-9]+}})
+
+int foo(__global int *input) {
+  *input += 5;
+
+  return 3;
+}
+
+__kernel void ocl_test_kernel(__global int *ocl_test_results) {
+  int a = foo(ocl_test_results);
+}

--- a/tests/Manual/testsuite/getkernelarginfo-wrong-binaries.cl
+++ b/tests/Manual/testsuite/getkernelarginfo-wrong-binaries.cl
@@ -1,0 +1,19 @@
+/*  'testsuite/getkernelarginfo-wrong-binaries.cl'  */
+
+// RUN: %occ-cli --method=GetKernelArgInfo --binary-file %s --kernel-name
+// ocl_test_kernel XFAIL: *
+//
+// This is a negative test for CORC-833.
+// CClang's GetKernelArgInfo should return valid error code instead of terminate
+// application when input binaries is invalid.
+//
+
+int foo(__global int *input) {
+  *input += 5;
+
+  return 3;
+}
+
+__kernel void ocl_test_kernel(__global int *ocl_test_results) {
+  int a = foo(ocl_test_results);
+}

--- a/tests/Manual/testsuite/gline-tables-only.cl
+++ b/tests/Manual/testsuite/gline-tables-only.cl
@@ -1,0 +1,17 @@
+/*  'testsuite/gline-tables-only.cl'  */
+
+// RUN: %occ-cli %s --cl-options=-gline-tables-only %cfg_path --cl-device=%cl_device --output=%t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+// CHECK: !dbg !{{[0-9]+}}
+// CHECK: !{{[0-9]+}} = !DILocation
+
+int foo(__global int *input) {
+  *input += 5;
+
+  return 3;
+}
+
+__kernel void ocl_test_kernel(__global int *ocl_test_results) {
+  int a = foo(ocl_test_results);
+}

--- a/tests/Manual/testsuite/implicit-function-declaration.cl
+++ b/tests/Manual/testsuite/implicit-function-declaration.cl
@@ -1,0 +1,6 @@
+// RUN: not %occ-cli %s --cl-device=%cl_device %cfg_path 2>&1 | FileCheck %s
+
+__kernel void test() {
+  bar();
+  // CHECK: error: use of undeclared identifier 'bar'
+}

--- a/tests/Manual/testsuite/optionEx-with-S.cl
+++ b/tests/Manual/testsuite/optionEx-with-S.cl
@@ -1,0 +1,10 @@
+// RUN: %occ-cli %s --cl-options-ex=-I/tmp/OCL-Sample %cfg_path --cl-device=%cl_device --output=%t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+// Regression test for the following bug.
+// If current working directory contains "-S", common clang produced no output
+// CPU runtime passes current working directory along with -I flag to cclang
+// via pszOptionsEx argument of Compile method.
+
+__kernel void test() {}
+// CHECK: void @test()

--- a/tests/Manual/testsuite/read_image_attributes.cl
+++ b/tests/Manual/testsuite/read_image_attributes.cl
@@ -1,0 +1,168 @@
+/*  'testsuite/read_image_attributes.cl'  */
+
+// RUN: %occ-cli %s %cfg_path --cl-device=%cl_device --output=%t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+// CHECK-NOT:     attributes{{.*}}readnone
+
+const sampler_t smp =
+    CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+void ocl_read_image1d_attributes(__read_only image1d_t img,
+                                 __global float *resf, __global int *resi) {
+  *resf += read_imagef(img, 0).x;
+  *resf += read_imagef(img, .0f).x;
+  *resf += read_imagef(img, smp, 0).x;
+  *resf += read_imagef(img, smp, .0f).x;
+
+  *resi += read_imagei(img, 0).x;
+  *resi += read_imagei(img, .0f).x;
+  *resi += read_imagei(img, smp, 0).x;
+  *resi += read_imagei(img, smp, .0f).x;
+
+  *resi += read_imageui(img, 0).x;
+  *resi += read_imageui(img, .0f).x;
+  *resi += read_imageui(img, smp, 0).x;
+  *resi += read_imageui(img, smp, .0f).x;
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0:#[0-9]+]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image1d_buffer_attributes(__read_only image1d_buffer_t img,
+                                        __global float *resf,
+                                        __global int *resi) {
+  *resf += read_imagef(img, 0).x;
+  *resi += read_imagei(img, 0).x;
+  *resi += read_imageui(img, 0).x;
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image1d_arr_attributes(__read_only image1d_array_t img,
+                                     __global float *resf, __global int *resi) {
+  *resf += read_imagef(img, (int2)(0)).x;
+  *resf += read_imagef(img, smp, (int2)(0)).x;
+  *resf += read_imagef(img, smp, (float2)(0)).x;
+
+  *resi += read_imagei(img, (int2)(0)).x;
+  *resi += read_imagei(img, smp, (int2)(0)).x;
+  *resi += read_imagei(img, smp, (float2)(0)).x;
+
+  *resi += read_imageui(img, (int2)(0)).x;
+  *resi += read_imageui(img, smp, (int2)(0)).x;
+  *resi += read_imageui(img, smp, (float2)(0)).x;
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image2d_attributes(__read_only image2d_t img,
+                                 __global float *resf, __global int *resi) {
+  *resf += read_imagef(img, (int2)0).x;
+  *resf += read_imagef(img, smp, (int2)0).x;
+  *resf += read_imagef(img, smp, (float2).0f).x;
+
+  *resi += read_imagei(img, (int2)0).x;
+  *resi += read_imagei(img, smp, (int2)0).x;
+  *resi += read_imagei(img, smp, (float2).0f).x;
+
+  *resi += read_imageui(img, (int2)0).x;
+  *resi += read_imageui(img, smp, (int2)0).x;
+  *resi += read_imageui(img, smp, (float2).0f).x;
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image2d_array_attributes(__read_only image2d_array_t img,
+                                       __global float *resf,
+                                       __global int *resi) {
+  *resf += read_imagef(img, (int4)0).x;
+  *resf += read_imagef(img, smp, (int4)0).x;
+  *resf += read_imagef(img, smp, (float4).0f).x;
+
+  *resi += read_imagei(img, (int4)0).x;
+  *resi += read_imagei(img, smp, (int4)0).x;
+  *resi += read_imagei(img, smp, (float4).0f).x;
+
+  *resi += read_imageui(img, (int4)0).x;
+  *resi += read_imageui(img, smp, (int4)0).x;
+  *resi += read_imageui(img, smp, (float4).0f).x;
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image3d_attributes(__read_only image3d_t img,
+                                 __global float *resf, __global int *resi) {
+  *resf += read_imagef(img, (int4)0).x;
+  *resf += read_imagef(img, smp, (int4)0).x;
+  *resf += read_imagef(img, smp, (float4).0f).x;
+
+  *resi += read_imagei(img, (int4)0).x;
+  *resi += read_imagei(img, smp, (int4)0).x;
+  *resi += read_imagei(img, smp, (float4).0f).x;
+
+  *resi += read_imageui(img, (int4)0).x;
+  *resi += read_imageui(img, smp, (int4)0).x;
+  *resi += read_imageui(img, smp, (float4).0f).x;
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image2d_depth_attributes(__read_only image2d_depth_t img,
+                                       __global float *resf,
+                                       __global int *resi) {
+  *resf += read_imagef(img, (int2)0);
+  *resf += read_imagef(img, smp, (int2)0);
+  *resf += read_imagef(img, smp, (float2).0f);
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+void ocl_read_image2d_array_depth_attributes(
+    __read_only image2d_array_depth_t img, __global float *resf,
+    __global int *resi) {
+  *resf += read_imagef(img, (int4)0);
+  *resf += read_imagef(img, smp, (int4)0);
+  *resf += read_imagef(img, smp, (float4).0f);
+}
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+// CHECK:         declare{{.*}}read_image{{.*}}[[ATTRS0]]
+
+// CHECK-DAG:     attributes [[ATTRS0]]{{.*}}convergent

--- a/tests/Manual/testsuite/werror-option.cl
+++ b/tests/Manual/testsuite/werror-option.cl
@@ -1,0 +1,12 @@
+// RUN: %occ-cli %s --cl-options=-Werror %cfg_path --cl-device=%cl_device --output=%t.bc
+// XFAIL: *
+
+struct Node;
+typedef struct {
+  __global struct Node *pNext;
+} Node;
+
+__kernel void test(__global Node *pNodes) {
+  __global Node *pNew;
+  pNodes->pNext = pNew;
+}

--- a/tests/Manual/testsuite/xclang.cl
+++ b/tests/Manual/testsuite/xclang.cl
@@ -1,0 +1,8 @@
+// RUN: not %occ-cli %s --cl-options="-Werror -Wuninitialized"
+// --cl-device=%cl_device %cfg_path --output=%t.bc 2>&1 | FileCheck %s
+
+__kernel void k() {
+  // CHECK: error: variable 'p' is uninitialized when used here
+  int *p;
+  printf("%d\n", *p);
+}

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -1,0 +1,51 @@
+"""
+Lit configuration file for opencl-clang tests.
+"""
+
+import os
+
+import lit.formats
+from lit.llvm import llvm_config
+
+config.name = "opencl-clang"
+
+config.test_format = lit.formats.ShTest()
+
+config.suffixes = [".cl", ".test"]
+
+# Skip the Conformance folder to shorten CI run time on CPU-limited runner.
+config.excludes = ["CMakeLists.txt", "Conformance"]
+
+config.test_source_root = os.path.dirname(__file__)
+
+config.test_exec_root = config.opencl_clang_obj_root
+
+llvm_config.use_default_substitutions()
+
+llvm_config.use_clang()
+
+occ_cli = os.path.join(config.opencl_clang_tools_dir, "occ-cli")
+cfg_path = os.path.join(config.opencl_clang_src_root, "tests", "occ-cli")
+cl_device = getattr(config, "cl_device", "DEFAULT")
+
+config.substitutions.extend(
+    [
+        ("%occ-cli", occ_cli),
+        ("%cfg_path", "--config-path=" + cfg_path),
+        ("%cl_device", cl_device),
+    ]
+)
+
+if "PATH" in os.environ:
+    config.environment["PATH"] = os.path.pathsep.join(
+        [config.opencl_clang_tools_dir, os.environ["PATH"]]
+    )
+else:
+    config.environment["PATH"] = config.opencl_clang_tools_dir
+
+if "LD_LIBRARY_PATH" in os.environ:
+    config.environment["LD_LIBRARY_PATH"] = os.path.pathsep.join(
+        [config.llvm_libs_dir, os.environ["LD_LIBRARY_PATH"]]
+    )
+else:
+    config.environment["LD_LIBRARY_PATH"] = config.llvm_libs_dir

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -1,0 +1,24 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
+config.llvm_libs_dir = lit_config.substitute(path(r"@LLVM_LIBRARY_DIR@"))
+config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))
+
+config.clang_tools_dir = lit_config.substitute(path(r"@CLANG_TOOLS_DIR@"))
+
+config.opencl_clang_src_root = lit_config.substitute(path(r"@CMAKE_CURRENT_SOURCE_DIR@/.."))
+config.opencl_clang_obj_root = lit_config.substitute(path(r"@CMAKE_CURRENT_BINARY_DIR@"))
+config.opencl_clang_tools_dir = lit_config.substitute(path(r"@LLVM_TOOLS_DIR@"))
+
+config.cl_device = "@OPENCL_CLANG_TEST_DEVICE@"
+
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@LLVM_TARGET_TRIPLE@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")

--- a/tests/occ-cli/CMakeLists.txt
+++ b/tests/occ-cli/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(OPENCL_CLANG_LIBRARY_NAME ${TARGET_NAME})
+set(TARGET_NAME occ-cli)
+
+include_directories("${OPENCL_CLANG_SOURCE_DIR}")
+link_directories("${LLVM_LIBRARY_DIRS}")
+
+add_executable(${TARGET_NAME}
+  main.cpp
+  common.cpp
+  compile.cpp
+  IniFiles.cpp
+)
+
+add_dependencies(${TARGET_NAME} ${OPENCL_CLANG_LIBRARY_NAME})
+
+target_link_libraries( ${TARGET_NAME}
+                       ${OPENCL_CLANG_LIBRARY_NAME} )

--- a/tests/occ-cli/ConfExt.ini
+++ b/tests/occ-cli/ConfExt.ini
@@ -1,0 +1,80 @@
+[DEFAULT]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64,+cl_khr_fp16,+__opencl_c_images
+pszOpenCLVer=120
+[BDW_WIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64,+cl_khr_image2d_from_buffer
+pszOpenCLVer=200
+[HSW_WIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64
+pszOpenCLVer=120
+[SKL_WIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64,+cl_khr_image2d_from_buffer
+pszOpenCLVer=200
+[IVB_WIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64
+pszOpenCLVer=120
+[SNB_WIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64
+pszOpenCLVer=120
+[GEN75_WIN]
+pszOptions=-cl-kernel-arg-info -triple igil_64_GEN75  -pch-gpu
+pszOptionsEx= -include CTHeader.h -disable-llvm-optzns -fblocks -I. -D__ENABLE_GENERIC__=1 -emit-llvm-bc -D__HW_PLATFORM_GEN__=1 -cl-ext=-all,+cl_khr_gl_sharing,+cl_khr_gl_event,+cl_khr_d3d10_sharing,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_3d_image_writes,+cl_intel_ctz,+cl_intel_sub_groups
+pszOpenCLVer=120
+[GEN8_WIN]
+pszOptions=-cl-kernel-arg-info -triple igil_64_GEN8 -pch-gpu
+pszOptionsEx= -include CTHeader.h -disable-llvm-optzns -fblocks -I. -D__ENABLE_GENERIC__=1 -emit-llvm-bc -D__HW_PLATFORM_GEN__=2 -cl-ext=-all,+cl_khr_gl_sharing,+cl_khr_gl_event,+cl_khr_d3d10_sharing,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_3d_image_writes,+cl_intel_ctz,+cl_intel_sub_groups
+pszOpenCLVer=200
+[GEN9_WIN]
+pszOptions=-cl-kernel-arg-info -triple igil_64_GEN9 -pch-gpu
+pszOptionsEx= -include CTHeader.h -disable-llvm-optzns -fblocks -I. -D__ENABLE_GENERIC__=1 -emit-llvm-bc -D__HW_PLATFORM_GEN__=4 -cl-ext=-all,+cl_khr_gl_sharing,+cl_khr_gl_event,+cl_khr_d3d10_sharing,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_3d_image_writes,+cl_intel_ctz,+cl_intel_sub_groups,+cl_khr_fp16
+pszOpenCLVer=200
+[HSW_LIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_fp64
+pszOpenCLVer=120
+[WST_LIN]
+pszOptions= -cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_fp64
+pszOpenCLVer=120
+[IVB_LIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_fp64
+pszOpenCLVer=120
+[SKL_LIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_fp64
+pszOpenCLVer=120
+[KBL_WIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -mstackrealign -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_fp64,+cl_khr_image2d_from_buffer
+pszOpenCLVer=210
+[BXT_WIN]
+pszOptions= -pch-cpu
+pszOptionsEx= -mstackrealign -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_dx9_media_sharing,+cl_intel_dx9_media_sharing,+cl_khr_d3d11_sharing,+cl_khr_gl_sharing,+cl_khr_image2d_from_buffer
+pszOpenCLVer=200
+[DNW_LIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir,+cl_khr_fp64
+pszOpenCLVer=120
+[GEN75_LIN]
+pszOptions=-cl-kernel-arg-info -triple igil_64_GEN75  -pch-gpu
+pszOptionsEx= -include CTHeader.h -disable-llvm-optzns -fblocks -I. -D__ENABLE_GENERIC__=1 -emit-llvm-bc -D__HW_PLATFORM_GEN__=1 -cl-ext=-all,+cl_khr_gl_sharing,+cl_khr_gl_event,+cl_khr_d3d10_sharing,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_3d_image_writes,+cl_intel_subgroups,+cl_khr_fp16,+cl_khr_fp64,+cl_intel_ctz
+pszOpenCLVer=120
+[GEN8_LIN]
+pszOptions=-cl-kernel-arg-info -triple igil_64_GEN8 -pch-gpu
+pszOptionsEx= -include CTHeader.h -disable-llvm-optzns -fblocks -I. -D__ENABLE_GENERIC__=1 -emit-llvm-bc -D__HW_PLATFORM_GEN__=2 -cl-ext=-all,+cl_khr_gl_sharing,+cl_khr_gl_event,+cl_khr_d3d10_sharing,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_3d_image_writes,+cl_intel_subgroups,+cl_khr_fp16,+cl_khr_fp64,+cl_intel_ctz
+pszOpenCLVer=120
+[GEN9_LIN]
+pszOptions=-cl-kernel-arg-info -triple igil_64_GEN9 -pch-gpu
+pszOptionsEx= -include CTHeader.h -disable-llvm-optzns -fblocks -I. -D__ENABLE_GENERIC__=1 -emit-llvm-bc -D__HW_PLATFORM_GEN__=4 -cl-ext=-all,+cl_khr_gl_sharing,+cl_khr_gl_event,+cl_khr_d3d10_sharing,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_3d_image_writes,+cl_intel_subgroups,+cl_khr_fp16,+cl_intel_ctz
+pszOpenCLVer=200
+[BXT_LIN]
+pszOptions=-cl-kernel-arg-info -pch-cpu
+pszOptionsEx= -I. -mstackrealign -D__IMAGE_SUPPORT__=1 -cl-ext=-all,+cl_khr_icd,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_byte_addressable_store,+cl_khr_depth_images,+cl_khr_3d_image_writes,+cl_intel_exec_by_local_thread,+cl_khr_spir
+pszOpenCLVer=120

--- a/tests/occ-cli/IniFiles.cpp
+++ b/tests/occ-cli/IniFiles.cpp
@@ -1,0 +1,73 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file IniFiles.cpp
+
+\*****************************************************************************/
+
+#include "IniFiles.h"
+
+#include <fstream>
+#include <iostream>
+using namespace std;
+
+bool IniFile::Open() {
+  ifstream ini_file(fileDir.c_str());
+  if (!ini_file.is_open()) {
+    cerr << "Can't read " + fileDir + " file!" << endl;
+    return false;
+  }
+
+  heads.clear();
+  string tmp = "", fKey = "";
+  while (getline(ini_file, tmp)) {
+    size_t pos = tmp.find("=");
+
+    if (pos == string::npos) {
+      // '=' not found, added first key
+      tmp.erase(tmp.find(']'));
+      tmp.erase(tmp.begin());
+      heads[tmp].clear();
+      fKey = tmp;
+    } else {
+      // Add new second Key
+      string secondKey, keyVal;
+      secondKey = tmp.substr(0, pos);
+      keyVal = tmp.substr(pos + 1, tmp.length());
+      heads[fKey][secondKey] = keyVal;
+    }
+  }
+  ini_file.close();
+
+  cout << "Read " + fileDir + " config file success." << endl;
+  return true;
+}
+
+string IniFile::GetSecondKeyVal(string firstKey, string secondKey) {
+  if (heads.find(firstKey) == heads.end()) {
+    cerr << "First key : " + firstKey + " not found!" << endl;
+    return "";
+  }
+
+  if (heads[firstKey].find(secondKey) == heads[firstKey].end()) {
+    cerr << "Second key : " + secondKey + " not found!" << endl;
+    return "";
+  }
+
+  if (verbose) {
+    cout << "Read option : " + secondKey + " = " + heads[firstKey][secondKey]
+         << endl;
+  }
+  return heads[firstKey][secondKey];
+}

--- a/tests/occ-cli/IniFiles.h
+++ b/tests/occ-cli/IniFiles.h
@@ -1,0 +1,40 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file IniFiles.h
+
+\*****************************************************************************/
+
+#ifndef _INI_FILES_
+#define _INI_FILES_
+
+#include <map>
+#include <string>
+
+class IniFile {
+public:
+  IniFile(std::string _fileDir, int _verbose = 0)
+      : fileDir(_fileDir), verbose(_verbose) {}
+
+  bool Open();
+  std::string GetSecondKeyVal(std::string firstKey, std::string secondKey);
+
+private:
+  std::map<std::string, std::map<std::string, std::string>> heads;
+  std::string fileDir;
+  // verbose != 0 enable debug messages
+  int verbose;
+};
+
+#endif // _INI_FILES_

--- a/tests/occ-cli/common.cpp
+++ b/tests/occ-cli/common.cpp
@@ -1,0 +1,39 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file common.cpp
+
+\*****************************************************************************/
+
+#include "common.h"
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+using namespace std;
+
+string readFile(const string &filename, ios_base::openmode mode) {
+  ifstream file(filename, mode);
+  if (!file.is_open()) {
+    cerr << "Failed to open file " << filename << endl;
+    return string();
+  }
+
+  // copies all data into buffer
+  string buffer((istreambuf_iterator<char>(file)),
+                (istreambuf_iterator<char>()));
+  file.close();
+  return buffer;
+}

--- a/tests/occ-cli/common.h
+++ b/tests/occ-cli/common.h
@@ -1,0 +1,27 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file common.h
+
+\*****************************************************************************/
+
+#ifndef _COMMON_
+#define _COMMON_
+
+#include <string>
+#include <fstream>
+
+std::string readFile(const std::string &filename, std::ios_base::openmode mode = std::ios_base::in);
+
+#endif // _COMMON_

--- a/tests/occ-cli/compile.cpp
+++ b/tests/occ-cli/compile.cpp
@@ -1,0 +1,326 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file compile.cpp
+
+\*****************************************************************************/
+
+#include "IniFiles.h"
+#include "common.h"
+#include "common_clang.h"
+#include "main.h"
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+using namespace std;
+using namespace Intel::OpenCL::ClangFE;
+
+void printCompileUsage(const string&);
+
+int compile(const vector<string> &args) {
+  if (args.size() <= 1) {
+    cerr << "At least kernel name should be specified!" << endl;
+    return -1;
+  }
+
+  // read options
+  const string ccl_compile_version = "0.2.4";
+  string cl_options = "";
+  string cl_optionsEx = "";
+  string cl_version = "";
+  string cl_device = "";
+  string cfg_path = "";
+  string ir_file = "";
+  string cl_file_path;
+
+  int verbose = 0;
+
+  bool half = false;
+  bool doubles = false;
+  bool subgroups = false;
+  bool channels = false;
+
+  for (const auto &arg : args) {
+    // searching --help parameter
+    string arg_name("--help");
+    if (arg.find(arg_name) != string::npos) {
+      printCompileUsage(args[0]);
+      return 0;
+    }
+
+    // searching --version parameter
+    arg_name = "--version";
+    if (arg.find(arg_name) != string::npos) {
+      cout << ccl_compile_version << endl;
+      return 0;
+    }
+
+    // searching --verbose parameter
+    arg_name = "--verbose";
+    if (arg.find(arg_name) != string::npos) {
+      verbose = 1;
+      continue;
+    }
+
+    // searching --cl-options parameter
+    arg_name = "--cl-options=";
+    if (arg.find(arg_name) != string::npos) {
+      cl_options = string(arg.c_str() + arg_name.size());
+      continue;
+    }
+
+    // searching --cl-options-ex parameter
+    arg_name = "--cl-options-ex=";
+    if (arg.find(arg_name) != string::npos) {
+      cl_optionsEx = string(arg.c_str() + arg_name.size());
+      continue;
+    }
+
+    // searching --cl-version parameter
+    arg_name = "--cl-version=";
+    if (arg.find(arg_name) != string::npos) {
+      cl_version = string(arg.c_str() + arg_name.size());
+      continue;
+    }
+
+    // searching --cl-device parameter
+    arg_name = "--cl-device=";
+    if (arg.find(arg_name) != string::npos) {
+      cl_device = string(arg.c_str() + arg_name.size());
+      transform(cl_device.begin(), cl_device.end(), cl_device.begin(),
+                ::toupper);
+      continue;
+    }
+
+    // searching --use-half option
+    arg_name = "--use-half";
+    if (arg.find(arg_name) != string::npos) {
+      half = true;
+      continue;
+    }
+
+    // searching --use-double option
+    arg_name = "--use-double";
+    if (arg.find(arg_name) != string::npos) {
+      doubles = true;
+      continue;
+    }
+
+    // searching --use-subgroups option
+    arg_name = "--use-subgroups";
+    if (arg.find(arg_name) != string::npos) {
+      subgroups = true;
+      continue;
+    }
+
+    // searching --use-channels option
+    arg_name = "--use-channels";
+    if (arg.find(arg_name) != string::npos) {
+      channels = true;
+      continue;
+    }
+
+    // searching ConfExt.ini file
+    arg_name = "--config-path=";
+    if (arg.find(arg_name) != string::npos) {
+      cfg_path = string(arg.c_str() + arg_name.size());
+      continue;
+    }
+
+    // searching --output parameter
+    arg_name = "--output=";
+    if (arg.find(arg_name) != string::npos) {
+      ir_file = string(arg.c_str() + arg_name.size());
+      continue;
+    }
+
+    cl_file_path = arg;
+  }
+
+  if (cl_file_path.empty()) {
+    cout << "Please specify <cl_file_path>" << endl;
+    return -1;
+  }
+
+  string cl_program_source = readFile(cl_file_path);
+  if (cl_program_source.empty()) {
+    return -1;
+  }
+
+  IniFile ini(cfg_path + "/ConfExt.ini", verbose);
+  if (!ini.Open()) {
+    return -1;
+  }
+
+  cl_options += ' ' + ini.GetSecondKeyVal(cl_device, "pszOptions");
+
+  // The order of extension in cl_optionsEx is as the following:
+  // 1. Extensions defined in the config file
+  // 2. Extensions specified via -cl-options-ex options of occ-cli
+  // 3. Extensions enabled by -use-<extension> options of occ-cli
+  // Note that former extension in cl_optionsEx overwrite previous.
+  cl_optionsEx.insert(0, ini.GetSecondKeyVal(cl_device, "pszOptionsEx")+' ');
+
+  // Enable device extensions specified via command line
+  string device_extensions("-cl-ext=");
+  if (half) {
+    device_extensions += "+cl_khr_fp16,";
+    cl_options += " -D cl_khr_fp16";
+  }
+  if (doubles) {
+    device_extensions += "+cl_khr_fp64,";
+    cl_options += " -D cl_khr_fp64";
+  }
+  if (subgroups) {
+    device_extensions += "+cl_khr_subgroups,";
+    cl_options += " -D cl_khr_subgroups";
+  }
+  if (channels) {
+    device_extensions += "+cl_intel_channels,";
+    cl_options += " -D cl_intel_channels";
+  }
+  if (device_extensions != "-cl-ext=") {
+    cl_optionsEx += ' ' + device_extensions;
+  }
+
+  if (cl_version.empty()) {
+    cl_version = ini.GetSecondKeyVal(cl_device, "pszOpenCLVer");
+  }
+
+  if (verbose != 0) {
+    cout << "pszOptions: " << cl_options.c_str() << endl;
+    cout << "pszOptionsEx: " << cl_optionsEx.c_str() << endl;
+    cout << "pszOpenCLVer: " << cl_version.c_str() << endl;
+    cout << "pszProgramSource: " << endl
+         << string(30, '-') << endl
+         << cl_program_source.c_str() << endl
+         << string(30, '-') << endl;
+  }
+
+  // optional outbound pointer to the compilation results
+  unique_ptr<IOCLFEBinaryResult *> pBinaryResult(new IOCLFEBinaryResult *);
+  int err = Compile(cl_program_source.c_str(), NULL, 0, NULL, NULL, 0, cl_options.c_str(),
+    cl_optionsEx.c_str(), cl_version.c_str(), pBinaryResult.get());
+
+  if (err != 0) {
+    if (verbose == 0) {
+      cout << "pszOptions: " << cl_options.c_str() << endl;
+      cout << "pszOptionsEx: " << cl_optionsEx.c_str() << endl;
+      cout << "pszOpenCLVer: " << cl_version.c_str() << endl;
+    }
+
+    cerr << "ERROR: Failed to compile program:" << endl
+         << string(30, '-') << endl
+         << (*pBinaryResult)->GetErrorLog() << endl
+         << string(30, '-') << endl;
+    return err;
+  }
+
+  if ((*pBinaryResult)->GetIRSize() == 0) {
+    cerr << (*pBinaryResult)->GetErrorLog() << endl;
+    cerr << static_cast<unsigned int>((*pBinaryResult)->GetIRSize()) << endl;
+    return -1;
+  }
+
+  cout << "Kernel " << cl_file_path << " successfully compiled" << endl;
+
+  if (ir_file == "-") {
+    fwrite((*pBinaryResult)->GetIR(), sizeof(char),
+           (*pBinaryResult)->GetIRSize(), stdout);
+  } else if (!ir_file.empty()) {
+    FILE *pFile;
+    pFile = fopen(ir_file.c_str(), "wb");
+    if (!pFile) {
+      cerr << "Can't open " << ir_file << ".\n";
+      return -1;
+    }
+    fwrite((*pBinaryResult)->GetIR(), sizeof(char),
+           (*pBinaryResult)->GetIRSize(), pFile);
+    fclose(pFile);
+    cout << "IR file saved to : " << ir_file.c_str() << endl;
+
+    if (verbose != 0) {
+      cout << "IR file size: " << (*pBinaryResult)->GetIRSize() / 1024 << " kB"
+           << endl;
+    }
+  }
+  return 0;
+}
+
+int checkCompileOptions(const vector<string>& args) {
+  cout << "Not implemented yet" << endl;
+  return 0;
+}
+
+void printCompileUsage(const string &executable) {
+  // OVERVIEW
+  cout << "OVERVIEW: Compile .cl" << endl << endl;
+
+  // USAGE
+  cout << "USAGE: " << executable
+            << " Compile --cl-device=<device_name> --config-path=<path> "
+               "[options] <cl_file_path>"
+            << endl
+            << endl;
+
+  // OPTIONS
+  cout
+      << "OPTIONS:" << endl
+      << " --cl-device=<device_name>   - Specify device name from config file"
+      << endl
+      << " --config-path=<path>        - Path to config file" << endl
+      << endl
+      << " --output=<file_name>        - Override output file name generated "
+         "by compile cl file"
+      << endl
+      << " --cl-options=<cl_option>    - OpenCL application supplied options"
+      << endl
+      << " --cl-options-ex=<cl_option> - Internal extra options supplied by "
+         "runtime"
+      << endl
+      << " --use-half                  - Add 'cl_khr_fp16' to OpenCL options"
+      << endl
+      << " --use-double                - Add 'cl_khr_fp64' to OpenCL options"
+      << endl
+      << " --use-subgroups             - Add 'cl_khr_subgroups' to OpenCL "
+         "options"
+      << endl
+      << " --use-channels              - Add 'cl_intel_channels' to OpenCL "
+         "options"
+      << endl
+      << " --cl-version=<cl_version>   - OpenCL version string - '120' for "
+         "OpenCL 1.2, '200' for OpenCL 2.0, ..."
+      << endl;
+
+  cout << " misc:" << endl
+            << " --help                      - Display available options"
+            << endl
+            << " --version                   - Print occ-cli version"
+            << endl
+            << " --verbose                   - Print addition information"
+            << endl
+            << endl;
+
+  // CONFIG FILE
+  cout << "CONFIG FILE:" << endl
+            << "[<device_name>]" << endl
+            << "pszOptions=<options>" << endl
+            << "pszOptionsEx=<options>" << endl
+            << "pszOpenCLVer=<version>" << endl;
+
+}

--- a/tests/occ-cli/main.cpp
+++ b/tests/occ-cli/main.cpp
@@ -1,0 +1,82 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file main.cpp
+
+\*****************************************************************************/
+
+#include "main.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+using namespace std;
+
+void printUsage(const string &);
+
+int main(int argc, char *argv[]) {
+  try {
+    vector<string> args(argc);
+    transform(argv, argv + argc, args.begin(),
+              [](char *c_str) { return string(c_str); });
+
+    if (argc == 1) {
+      printUsage(args[0]);
+      return 0;
+    }
+
+    string method = "compile";
+    find_if(args.begin(), args.end(), [&](const string &s) {
+      string methodParam = "--method=";
+      auto it = s.find(methodParam);
+      if (it != string::npos) {
+        method.assign(s.begin() + it + methodParam.size(), s.end());
+      }
+      return it != string::npos;
+    });
+
+    transform(method.begin(), method.end(), method.begin(), ::tolower);
+
+    int retvalue = 0;
+    if (method == "compile") {
+      retvalue = compile(args);
+    } else if (method == "checkcompileoptions") {
+      retvalue = checkCompileOptions(args);
+    } else {
+      cerr << "Undefined method " << method << "!" << endl;
+      retvalue = -1;
+    }
+    return retvalue;
+  } catch (std::exception &e) {
+    // catch std::bad_array_new_length and std::bad_alloc
+    cerr << e.what() << endl;
+    return -1;
+  }
+}
+
+void printUsage(const string &executable) {
+  cout << "Usage: " << endl;
+  cout << "\t " << executable << " --method=methodName [options]" << endl;
+  cout << endl;
+  cout << "Available methods: " << endl;
+  cout << "\t CheckCompileOptions" << endl;
+  cout << "\t CheckLinkOptions" << endl;
+  cout << "\t Compile" << endl;
+  cout << "\t Link" << endl;
+  cout << "\t GetKernelArgInfo" << endl;
+  cout << endl;
+  cout << "For details type: " << endl;
+  cout << "\t " << executable << " --method=methodName --help" << endl;
+}

--- a/tests/occ-cli/main.h
+++ b/tests/occ-cli/main.h
@@ -1,0 +1,29 @@
+/*****************************************************************************\
+
+Copyright(c) Intel Corporation(2009 - 2016).
+
+INTEL MAKES NO WARRANTY OF ANY KIND REGARDING THE CODE.THIS CODE IS
+LICENSED ON AN "AS IS" BASIS AND INTEL WILL NOT PROVIDE ANY SUPPORT,
+ASSISTANCE, INSTALLATION, TRAINING OR OTHER SERVICES.INTEL DOES NOT
+PROVIDE ANY UPDATES, ENHANCEMENTS OR EXTENSIONS.INTEL SPECIFICALLY
+DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NONINFRINGEMENT, FITNESS FOR ANY
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY.Intel disclaims all liability,
+including liability for infringement of any proprietary rights, relating to
+use of the code.No license, express or implied, by estoppel or otherwise,
+to any intellectual property rights is granted herein.
+
+\file  main.h
+
+\*****************************************************************************/
+
+#ifndef _MAIN_
+#define _MAIN_
+
+#include <string>
+#include <vector>
+
+int checkCompileOptions(const std::vector<std::string>& args);
+int checkLinkOptions(const std::vector<std::string>& args);
+int compile(const std::vector<std::string>& args);
+
+#endif // _MAIN_


### PR DESCRIPTION
Adapt test CMake files and lit config files.
Only tests/Manual/testsuite folder is backported. cl-ext-option.cl in this test folder can validate `-cl-std=` for future cherry-pick of #752.

Don't full cherry-pick test files, as they will bloat the repo size.

(partial cherry picked from commit 5a5b1f94315f4cd5b09ad11cf88da8e464e7ba2f)