### PR TITLE
Reject unrecognized -cl-std= values instead of silently defaulting

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -473,6 +473,12 @@ int CompileOptionsParser::processOptions(const char *pszOptions,
   std::unique_ptr<OpenCLArgList> pArgs(
       m_optTbl.ParseArgs(pszOptions, missingArgIndex, missingArgCount));
 
+  // -cl-std= only accepts the fixed set of values defined in
+  // opencl_clang_options.td to avoid masking a user error.
+  std::string unknownArgs = pArgs->getFilteredArgs(OPT_COMPILE_UNKNOWN);
+  if (unknownArgs.find("-cl-std=") != std::string::npos)
+    return -1;
+
   // post process logic
   m_sourceName =
       m_commonFilter.processOptions(*pArgs, pszOptionsEx, m_effectiveArgs);

--- a/tests/Manual/testsuite/cl-std-invalid-option.cl
+++ b/tests/Manual/testsuite/cl-std-invalid-option.cl
@@ -1,0 +1,3 @@
+// RUN: not %occ-cli %s --cl-options="-triple spir-unknown-unknown -cl-std=CL1.3" --cl-device=%cl_device %cfg_path --output=%t.bc
+
+__kernel void MyKernel(__global int *pInt) { *pInt = 0; }

--- a/tests/occ-cli/compile.cpp
+++ b/tests/occ-cli/compile.cpp
@@ -225,9 +225,10 @@ int compile(const vector<string> &args) {
     }
 
     cerr << "ERROR: Failed to compile program:" << endl
-         << string(30, '-') << endl
-         << (*pBinaryResult)->GetErrorLog() << endl
          << string(30, '-') << endl;
+    if (*pBinaryResult)
+      cerr << (*pBinaryResult)->GetErrorLog() << endl;
+    cerr << string(30, '-') << endl;
     return err;
   }
 


### PR DESCRIPTION
Previously an unknown -cl-std= value (e.g. a typo or unsupported version) fell through Compile()'s option parsing unnoticed and silently defaulted to CL1.2, masking user error. Reject it explicitly in CompileOptionsParser::processOptions instead.

Also fix tests/occ-cli crash on the new test.