### PR TITLE
Refine test occ-cli error output: print err code

### DIFF
--- a/tests/occ-cli/compile.cpp
+++ b/tests/occ-cli/compile.cpp
@@ -229,6 +229,7 @@ int compile(const vector<string> &args) {
     if (*pBinaryResult)
       cerr << (*pBinaryResult)->GetErrorLog() << endl;
     cerr << string(30, '-') << endl;
+    cerr << "err: " << err << endl;
     return err;
   }
 


### PR DESCRIPTION
cl-std-invalid-option.cl only prints empty build log. This PR refines it to have:
err: -43
which is CL_INVALID_BUILD_OPTIONS.