### PR TITLE
[ocl-open-170] Fix space escape in `--cl-options="-s /path\ with\ spaces/kernel.cl"` (#712)

### DIFF
--- a/options.h
+++ b/options.h
@@ -238,8 +238,12 @@ void quoted_tokenize(OutIt dest, llvm::StringRef str, llvm::StringRef delims,
   while (ptr < end) {
     char c = str[ptr];
     if (c == escape) {
-      tok += c;
-      is_escaped = is_escaped ? false : true;
+      if (is_escaped) {
+        tok += c;
+        is_escaped = false;
+      } else {
+        is_escaped = true;
+      }
     } else if (c == quote) {
       if (is_escaped) {
         tok += c;
@@ -248,9 +252,9 @@ void quoted_tokenize(OutIt dest, llvm::StringRef str, llvm::StringRef delims,
         in_quote = in_quote ? false : true;
       }
     } else if (delims.find(c) != llvm::StringRef::npos) {
-      is_escaped = false;
-      if (in_quote) {
+      if (is_escaped || in_quote) {
         tok += c;
+        is_escaped = false;
       } else {
         *(dest++) = tok;
         tok.clear();

--- a/tests/Manual/testsuite/s-option.cl
+++ b/tests/Manual/testsuite/s-option.cl
@@ -1,0 +1,55 @@
+// RUN: %occ-cli %s --cl-options="-g -s ./tmp/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-1
+
+// CHECK-1: !1 = !DIFile(filename: "tmp/kernel.cl",
+
+// absolute path
+
+// RUN: %occ-cli %s --cl-options="-g -s /tmp/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-2
+
+// CHECK-2: !1 = !DIFile(filename: "/tmp/kernel.cl",
+
+// more complicated test cases
+
+// RUN: %occ-cli %s --cl-options="-g -s ./tmp/../tmp/../tmp/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-3
+
+// CHECK-3: !1 = !DIFile(filename: "tmp/../tmp/../tmp/kernel.cl",
+
+// RUN: %occ-cli %s --cl-options="-g -s /tmp/../tmp/../tmp/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-4
+
+// CHECK-4: !1 = !DIFile(filename: "/tmp/../tmp/../tmp/kernel.cl",
+
+// test cases with spaces
+
+// RUN: %occ-cli %s --cl-options='-g -s "/path with spaces/kernel.cl"' --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-6
+
+// CHECK-6: !1 = !DIFile(filename: "/path with spaces/kernel.cl",
+
+// RUN: %occ-cli %s --cl-options="-g -s /path\ with\ spaces/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-7
+
+// CHECK-7: !1 = !DIFile(filename: "/path with spaces/kernel.cl",
+
+// non-ascii characters
+
+// RUN: %occ-cli %s --cl-options="-g -s /tmp/❶❷❸❹❺❻❼❽❾❿.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-8
+
+// CHECK-8: !1 = !DIFile(filename: "/tmp/\E2\9D\B6\E2\9D\B7\E2\9D\B8\E2\9D\B9\E2\9D\BA\E2\9D\BB\E2\9D\BC\E2\9D\BD\E2\9D\BE\E2\9D\BF.cl",
+
+// multiply slashes
+
+// RUN: %occ-cli %s --cl-options="-g -s /tmp//path///to//kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-9
+
+// Clang normalizes only the last segment.
+// CHECK-9: !1 = !DIFile(filename: "/tmp//path///to/kernel.cl",
+
+__kernel void test(__global int *text) {
+  int gid = get_global_id(0);
+  text[gid] += gid;
+}


### PR DESCRIPTION
Bug: delimiter branch ignores is_escaped, so \ (backslash-space) breaks the token instead of inserting a literal space.

Two fixes:
- escape char: don't add to tok; set is_escaped=true, or if already escaped emit literal \ and clear flag.
- Delimiter: check is_escaped (not just in_quote) before breaking token; clear is_escaped after consuming.

Assisted-by: Claude
(cherry picked from commit 65b270e6073849e18cb1e3246077adb9e3c412b7) Also add test tests/Manual/testsuite/s-option.cl.