### PR TITLE
Do not default to OpenCL C 1.2

### DIFF
--- a/options_compile.cpp
+++ b/options_compile.cpp
@@ -263,11 +263,6 @@ std::string EffectiveOptionsFilter::processOptions(const OpenCLArgList &args,
     }
   }
 
-  if (!iCLStdSet) {
-    effectiveArgs.push_back("-cl-std=CL1.2");
-    iCLStdSet = 120;
-  }
-
   effectiveArgs.push_back("-D");
   effectiveArgs.push_back("__OPENCL_VERSION__=" + m_opencl_ver);
   effectiveArgs.push_back("-x");


### PR DESCRIPTION
If user doesn't specifiy -cl-std option, just use clang's default value.