### PR TITLE
Fix opencl_clang name dependency for occ_cli

### DIFF
--- a/tests/occ-cli/CMakeLists.txt
+++ b/tests/occ-cli/CMakeLists.txt
@@ -10,5 +10,4 @@ add_executable(${OCC_CLI_TARGET_NAME}
   IniFiles.cpp
 )
 
-target_link_libraries( ${OCC_CLI_TARGET_NAME}
-                       ${TARGET_NAMEE} )
+target_link_libraries(${OCC_CLI_TARGET_NAME} ${TARGET_NAMEE})

--- a/tests/occ-cli/CMakeLists.txt
+++ b/tests/occ-cli/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(${TARGET_NAME}
   IniFiles.cpp
 )
 
-add_dependencies(${TARGET_NAME} ${OPENCL_CLANG_LIBRARY_NAME})
+add_dependencies(${TARGET_NAME} ${OPENCL_CLANG_LIBRARY_NAME}${BUILD_PLATFORM})
 
 target_link_libraries( ${TARGET_NAME}
                        ${OPENCL_CLANG_LIBRARY_NAME} )

--- a/tests/occ-cli/CMakeLists.txt
+++ b/tests/occ-cli/CMakeLists.txt
@@ -1,16 +1,14 @@
-set(TARGET_NAME occ-cli)
+set(OCC_CLI_TARGET_NAME occ-cli)
 
 include_directories("${OPENCL_CLANG_SOURCE_DIR}")
 link_directories("${LLVM_LIBRARY_DIRS}")
 
-add_executable(${TARGET_NAME}
+add_executable(${OCC_CLI_TARGET_NAME}
   main.cpp
   common.cpp
   compile.cpp
   IniFiles.cpp
 )
 
-add_dependencies(${TARGET_NAME} ${OPENCL_CLANG_LIBRARY_NAME}${BUILD_PLATFORM})
-
-target_link_libraries( ${TARGET_NAME}
-                       ${OPENCL_CLANG_LIBRARY_NAME} )
+target_link_libraries( ${OCC_CLI_TARGET_NAME}
+                       ${TARGET_NAMEE} )

--- a/tests/occ-cli/CMakeLists.txt
+++ b/tests/occ-cli/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(${OCC_CLI_TARGET_NAME}
   IniFiles.cpp
 )
 
-target_link_libraries(${OCC_CLI_TARGET_NAME} ${TARGET_NAMEE})
+target_link_libraries(${OCC_CLI_TARGET_NAME} ${TARGET_NAME})


### PR DESCRIPTION
The opencl_clang target name contains BUILD_PLATFORM