### PR TITLE
[ocl-open-210] Skip OpenCL 3.1 PCM generation when prebuilt clang lacks CL3.1 support (#814)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,24 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       ${CMAKE_MODULE_PATH}
       ${LLVM_CMAKE_DIR})
 
+    # A prebuilt clang may predate the CL3.1 patches carried in patches/clang
+    # (only applied when building clang from source, see below). Probe it so
+    # we don't try to generate a PCM with a -cl-std value the compiler rejects.
+    find_program(OPENCL_CLANG_PROBE_CLANG clang PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cl31_check.cl" "")
+    execute_process(
+        COMMAND ${OPENCL_CLANG_PROBE_CLANG} -cl-std=CL3.1 -x cl -fsyntax-only "${CMAKE_CURRENT_BINARY_DIR}/cl31_check.cl"
+        RESULT_VARIABLE CLANG_CL31_CHECK_RESULT
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(CLANG_CL31_CHECK_RESULT EQUAL 0)
+        set(CLANG_SUPPORTS_CL31 TRUE)
+    else()
+        set(CLANG_SUPPORTS_CL31 FALSE)
+        message(STATUS "[OPENCL-CLANG] ${OPENCL_CLANG_PROBE_CLANG} does not support -cl-std=CL3.1; skipping OpenCL 3.1 PCM generation")
+    endif()
+
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -72,8 +90,13 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     endif(LLVMSPIRV_INCLUDED_IN_LLVM)
 else(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(USE_PREBUILT_LLVM OFF)
+    set(CLANG_SUPPORTS_CL31 TRUE)
     find_package(Git REQUIRED)
 endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+
+if(NOT CLANG_SUPPORTS_CL31)
+  add_definitions(-DOPENCL_CLANG_NO_CL31_PCM)
+endif()
 
 include(AddLLVM)
 include(TableGen)

--- a/cl_headers/CMakeLists.txt
+++ b/cl_headers/CMakeLists.txt
@@ -81,20 +81,32 @@ set(OPTS -cl-ext=+all,-cl_khr_fp64,-__opencl_c_fp64)
 create_pcm(opencl-c-12-spir.pcm cl12spir opencl-c-base.h "${SPIR_TRIPLE};${CL12};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-20-spir.pcm cl20spir opencl-c-base.h "${SPIR_TRIPLE};${CL20};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-30-spir.pcm cl30spir opencl-c-base.h "${SPIR_TRIPLE};${CL30};${OPTS};${OPTS30}" "${DEPS}")
-create_pcm(opencl-c-31-spir.pcm cl31spir opencl-c-base.h "${SPIR_TRIPLE};${CL31};${OPTS};${OPTS30}" "${DEPS}")
 create_pcm(opencl-c-12-spir64.pcm cl12spir64 opencl-c-base.h "${SPIR64_TRIPLE};${CL12};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-20-spir64.pcm cl20spir64 opencl-c-base.h "${SPIR64_TRIPLE};${CL20};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-30-spir64.pcm cl30spir64 opencl-c-base.h "${SPIR64_TRIPLE};${CL30};${OPTS};${OPTS30}" "${DEPS}")
-create_pcm(opencl-c-31-spir64.pcm cl31spir64 opencl-c-base.h "${SPIR64_TRIPLE};${CL31};${OPTS};${OPTS30}" "${DEPS}")
 set(OPTS -cl-ext=+all)
 create_pcm(opencl-c-12-spir-fp64.pcm cl12spirfp64 opencl-c-base.h "${SPIR_TRIPLE};${CL12};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-20-spir-fp64.pcm cl20spirfp64 opencl-c-base.h "${SPIR_TRIPLE};${CL20};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-30-spir-fp64.pcm cl30spirfp64 opencl-c-base.h "${SPIR_TRIPLE};${CL30};${OPTS};${OPTS30};${OPTS30_FP64}" "${DEPS}")
-create_pcm(opencl-c-31-spir-fp64.pcm cl31spirfp64 opencl-c-base.h "${SPIR_TRIPLE};${CL31};${OPTS};${OPTS30};${OPTS30_FP64}" "${DEPS}")
 create_pcm(opencl-c-12-spir64-fp64.pcm cl12spir64fp64 opencl-c-base.h "${SPIR64_TRIPLE};${CL12};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-20-spir64-fp64.pcm cl20spir64fp64 opencl-c-base.h "${SPIR64_TRIPLE};${CL20};${OPTS}" "${DEPS}")
 create_pcm(opencl-c-30-spir64-fp64.pcm cl30spir64fp64 opencl-c-base.h "${SPIR64_TRIPLE};${CL30};${OPTS};${OPTS30};${OPTS30_FP64}" "${DEPS}")
-create_pcm(opencl-c-31-spir64-fp64.pcm cl31spir64fp64 opencl-c-base.h "${SPIR64_TRIPLE};${CL31};${OPTS};${OPTS30};${OPTS30_FP64}" "${DEPS}")
+
+set(CL31_PCM_TARGETS "")
+if(CLANG_SUPPORTS_CL31)
+    set(OPTS -cl-ext=+all,-cl_khr_fp64,-__opencl_c_fp64)
+    create_pcm(opencl-c-31-spir.pcm cl31spir opencl-c-base.h "${SPIR_TRIPLE};${CL31};${OPTS};${OPTS30}" "${DEPS}")
+    create_pcm(opencl-c-31-spir64.pcm cl31spir64 opencl-c-base.h "${SPIR64_TRIPLE};${CL31};${OPTS};${OPTS30}" "${DEPS}")
+    set(OPTS -cl-ext=+all)
+    create_pcm(opencl-c-31-spir-fp64.pcm cl31spirfp64 opencl-c-base.h "${SPIR_TRIPLE};${CL31};${OPTS};${OPTS30};${OPTS30_FP64}" "${DEPS}")
+    create_pcm(opencl-c-31-spir64-fp64.pcm cl31spir64fp64 opencl-c-base.h "${SPIR64_TRIPLE};${CL31};${OPTS};${OPTS30};${OPTS30_FP64}" "${DEPS}")
+    list(APPEND CL31_PCM_TARGETS
+        opencl-c-31-spir.pcm
+        opencl-c-31-spir64.pcm
+        opencl-c-31-spir-fp64.pcm
+        opencl-c-31-spir64-fp64.pcm
+    )
+endif()
 
 add_custom_target (
     opencl.pcm.target
@@ -103,19 +115,16 @@ add_custom_target (
     opencl-c-12-spir.pcm
     opencl-c-20-spir.pcm
     opencl-c-30-spir.pcm
-    opencl-c-31-spir.pcm
     opencl-c-12-spir64.pcm
     opencl-c-20-spir64.pcm
     opencl-c-30-spir64.pcm
-    opencl-c-31-spir64.pcm
     opencl-c-12-spir-fp64.pcm
     opencl-c-20-spir-fp64.pcm
     opencl-c-30-spir-fp64.pcm
-    opencl-c-31-spir-fp64.pcm
     opencl-c-12-spir64-fp64.pcm
     opencl-c-20-spir64-fp64.pcm
     opencl-c-30-spir64-fp64.pcm
-    opencl-c-31-spir64-fp64.pcm
+    ${CL31_PCM_TARGETS}
 )
 
 function(pack_to_obj SRC DST TAG)
@@ -138,40 +147,46 @@ else()
       opencl-c-12-spir.mod.cpp
       opencl-c-20-spir.mod.cpp
       opencl-c-30-spir.mod.cpp
-      opencl-c-31-spir.mod.cpp
       opencl-c-12-spir64.mod.cpp
       opencl-c-20-spir64.mod.cpp
       opencl-c-30-spir64.mod.cpp
-      opencl-c-31-spir64.mod.cpp
       opencl-c-12-spir-fp64.mod.cpp
       opencl-c-20-spir-fp64.mod.cpp
       opencl-c-30-spir-fp64.mod.cpp
-      opencl-c-31-spir-fp64.mod.cpp
       opencl-c-12-spir64-fp64.mod.cpp
       opencl-c-20-spir64-fp64.mod.cpp
       opencl-c-30-spir64-fp64.mod.cpp
-      opencl-c-31-spir64-fp64.mod.cpp
       module.modulemap.cpp
     )
+    if(CLANG_SUPPORTS_CL31)
+        list(APPEND CL_HEADERS_SRC
+          opencl-c-31-spir.mod.cpp
+          opencl-c-31-spir64.mod.cpp
+          opencl-c-31-spir-fp64.mod.cpp
+          opencl-c-31-spir64-fp64.mod.cpp
+        )
+    endif()
     # note the .pcm -> .mod extension change
     # this is a workaround for CMake bug that caused
     # dependency cycle in generated build rules
     pack_to_obj(opencl-c-12-spir.pcm    opencl-c-12-spir.mod.cpp   "PCM_OPENCL_C_12_SPIR_PCM")
     pack_to_obj(opencl-c-20-spir.pcm    opencl-c-20-spir.mod.cpp   "PCM_OPENCL_C_20_SPIR_PCM")
     pack_to_obj(opencl-c-30-spir.pcm    opencl-c-30-spir.mod.cpp   "PCM_OPENCL_C_30_SPIR_PCM")
-    pack_to_obj(opencl-c-31-spir.pcm    opencl-c-31-spir.mod.cpp   "PCM_OPENCL_C_31_SPIR_PCM")
     pack_to_obj(opencl-c-12-spir64.pcm  opencl-c-12-spir64.mod.cpp "PCM_OPENCL_C_12_SPIR64_PCM")
     pack_to_obj(opencl-c-20-spir64.pcm  opencl-c-20-spir64.mod.cpp "PCM_OPENCL_C_20_SPIR64_PCM")
     pack_to_obj(opencl-c-30-spir64.pcm  opencl-c-30-spir64.mod.cpp "PCM_OPENCL_C_30_SPIR64_PCM")
-    pack_to_obj(opencl-c-31-spir64.pcm  opencl-c-31-spir64.mod.cpp "PCM_OPENCL_C_31_SPIR64_PCM")
     pack_to_obj(opencl-c-12-spir-fp64.pcm    opencl-c-12-spir-fp64.mod.cpp   "PCM_OPENCL_C_12_SPIR_FP64_PCM")
     pack_to_obj(opencl-c-20-spir-fp64.pcm    opencl-c-20-spir-fp64.mod.cpp   "PCM_OPENCL_C_20_SPIR_FP64_PCM")
     pack_to_obj(opencl-c-30-spir-fp64.pcm    opencl-c-30-spir-fp64.mod.cpp   "PCM_OPENCL_C_30_SPIR_FP64_PCM")
-    pack_to_obj(opencl-c-31-spir-fp64.pcm    opencl-c-31-spir-fp64.mod.cpp   "PCM_OPENCL_C_31_SPIR_FP64_PCM")
     pack_to_obj(opencl-c-12-spir64-fp64.pcm  opencl-c-12-spir64-fp64.mod.cpp "PCM_OPENCL_C_12_SPIR64_FP64_PCM")
     pack_to_obj(opencl-c-20-spir64-fp64.pcm  opencl-c-20-spir64-fp64.mod.cpp "PCM_OPENCL_C_20_SPIR64_FP64_PCM")
     pack_to_obj(opencl-c-30-spir64-fp64.pcm  opencl-c-30-spir64-fp64.mod.cpp "PCM_OPENCL_C_30_SPIR64_FP64_PCM")
-    pack_to_obj(opencl-c-31-spir64-fp64.pcm  opencl-c-31-spir64-fp64.mod.cpp "PCM_OPENCL_C_31_SPIR64_FP64_PCM")
+    if(CLANG_SUPPORTS_CL31)
+        pack_to_obj(opencl-c-31-spir.pcm    opencl-c-31-spir.mod.cpp   "PCM_OPENCL_C_31_SPIR_PCM")
+        pack_to_obj(opencl-c-31-spir64.pcm  opencl-c-31-spir64.mod.cpp "PCM_OPENCL_C_31_SPIR64_PCM")
+        pack_to_obj(opencl-c-31-spir-fp64.pcm    opencl-c-31-spir-fp64.mod.cpp   "PCM_OPENCL_C_31_SPIR_FP64_PCM")
+        pack_to_obj(opencl-c-31-spir64-fp64.pcm  opencl-c-31-spir64-fp64.mod.cpp "PCM_OPENCL_C_31_SPIR64_FP64_PCM")
+    endif()
     pack_to_obj(module.modulemap  module.modulemap.cpp  "PCM_OPENCL_C_MODULE_MAP")
 endif()
 

--- a/cl_headers/OpenCL.rc
+++ b/cl_headers/OpenCL.rc
@@ -16,17 +16,25 @@ OPENCL_C_BASE_H                PCM   "opencl-c-base.h"
 OPENCL_C_12_SPIR_PCM           PCM   "opencl-c-12-spir.pcm"
 OPENCL_C_20_SPIR_PCM           PCM   "opencl-c-20-spir.pcm"
 OPENCL_C_30_SPIR_PCM           PCM   "opencl-c-30-spir.pcm"
+#ifndef OPENCL_CLANG_NO_CL31_PCM
 OPENCL_C_31_SPIR_PCM           PCM   "opencl-c-31-spir.pcm"
+#endif
 OPENCL_C_12_SPIR64_PCM         PCM   "opencl-c-12-spir64.pcm"
 OPENCL_C_20_SPIR64_PCM         PCM   "opencl-c-20-spir64.pcm"
 OPENCL_C_30_SPIR64_PCM         PCM   "opencl-c-30-spir64.pcm"
+#ifndef OPENCL_CLANG_NO_CL31_PCM
 OPENCL_C_31_SPIR64_PCM         PCM   "opencl-c-31-spir64.pcm"
+#endif
 OPENCL_C_12_SPIR_FP64_PCM      PCM   "opencl-c-12-spir-fp64.pcm"
 OPENCL_C_20_SPIR_FP64_PCM      PCM   "opencl-c-20-spir-fp64.pcm"
 OPENCL_C_30_SPIR_FP64_PCM      PCM   "opencl-c-30-spir-fp64.pcm"
+#ifndef OPENCL_CLANG_NO_CL31_PCM
 OPENCL_C_31_SPIR_FP64_PCM      PCM   "opencl-c-31-spir-fp64.pcm"
+#endif
 OPENCL_C_12_SPIR64_FP64_PCM    PCM   "opencl-c-12-spir64-fp64.pcm"
 OPENCL_C_20_SPIR64_FP64_PCM    PCM   "opencl-c-20-spir64-fp64.pcm"
 OPENCL_C_30_SPIR64_FP64_PCM    PCM   "opencl-c-30-spir64-fp64.pcm"
+#ifndef OPENCL_CLANG_NO_CL31_PCM
 OPENCL_C_31_SPIR64_FP64_PCM    PCM   "opencl-c-31-spir64-fp64.pcm"
+#endif
 OPENCL_C_MODULE_MAP            PCM   "module.modulemap"

--- a/opencl_clang.cpp
+++ b/opencl_clang.cpp
@@ -97,19 +97,27 @@ static bool GetHeaders(std::vector<Resource> &Result) {
                  {OPENCL_C_12_SPIR_PCM, "opencl-c-12-spir.pcm"},
                  {OPENCL_C_20_SPIR_PCM, "opencl-c-20-spir.pcm"},
                  {OPENCL_C_30_SPIR_PCM, "opencl-c-30-spir.pcm"},
+#ifndef OPENCL_CLANG_NO_CL31_PCM
                  {OPENCL_C_31_SPIR_PCM, "opencl-c-31-spir.pcm"},
+#endif
                  {OPENCL_C_12_SPIR64_PCM, "opencl-c-12-spir64.pcm"},
                  {OPENCL_C_20_SPIR64_PCM, "opencl-c-20-spir64.pcm"},
                  {OPENCL_C_30_SPIR64_PCM, "opencl-c-30-spir64.pcm"},
+#ifndef OPENCL_CLANG_NO_CL31_PCM
                  {OPENCL_C_31_SPIR64_PCM, "opencl-c-31-spir64.pcm"},
+#endif
                  {OPENCL_C_12_SPIR_FP64_PCM, "opencl-c-12-spir-fp64.pcm"},
                  {OPENCL_C_20_SPIR_FP64_PCM, "opencl-c-20-spir-fp64.pcm"},
                  {OPENCL_C_30_SPIR_FP64_PCM, "opencl-c-30-spir-fp64.pcm"},
+#ifndef OPENCL_CLANG_NO_CL31_PCM
                  {OPENCL_C_31_SPIR_FP64_PCM, "opencl-c-31-spir-fp64.pcm"},
+#endif
                  {OPENCL_C_12_SPIR64_FP64_PCM, "opencl-c-12-spir64-fp64.pcm"},
                  {OPENCL_C_20_SPIR64_FP64_PCM, "opencl-c-20-spir64-fp64.pcm"},
                  {OPENCL_C_30_SPIR64_FP64_PCM, "opencl-c-30-spir64-fp64.pcm"},
+#ifndef OPENCL_CLANG_NO_CL31_PCM
                  {OPENCL_C_31_SPIR64_FP64_PCM, "opencl-c-31-spir64-fp64.pcm"},
+#endif
                  {OPENCL_C_MODULE_MAP, "module.modulemap"}};
 
   Result.clear();


### PR DESCRIPTION
The out-of-tree build uses a prebuilt/system clang (USE_PREBUILT_LLVM), which doesn't have the CL3.1 clang patches from patches/clang applied (those only apply when building clang from source in-tree). This made opencl-c-31-spir.pcm generation fail with "invalid value 'CL3.1' in '-cl-std=CL3.1'".

Probe the resolved clang for -cl-std=CL3.1 support and skip generating/ packaging the CL3.1 PCM variants when unsupported, gating the runtime resource list in opencl_clang.cpp with OPENCL_CLANG_NO_CL31_PCM so GetHeaders() doesn't fail looking for a PCM that was never built.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
(cherry picked from commit 9363ff5d8d48d5554cfa25ac03b5b21037761935)

This fixes out-of-tree build.