### PR TITLE
Fix failure on windows.

### DIFF
--- a/tests/Manual/testsuite/s-option.cl
+++ b/tests/Manual/testsuite/s-option.cl
@@ -1,4 +1,4 @@
-// REQUIRES: linux
+// REQUIRES: system-linux
 
 // RUN: %occ-cli %s --cl-options="-g -s ./tmp/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
 // RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-1

--- a/tests/Manual/testsuite/s-option.cl
+++ b/tests/Manual/testsuite/s-option.cl
@@ -1,3 +1,5 @@
+// REQUIRES: linux
+
 // RUN: %occ-cli %s --cl-options="-g -s ./tmp/kernel.cl" --cl-device=%cl_device %cfg_path --output=%t.bc
 // RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-1
 

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/advect.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/advect.cl
@@ -347,4 +347,4 @@ limitClamp(__global float *phi,
 
 
 // buildOptions=-D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini  -D FIELDOFFX=0 -D VELOFFX=1 -D FIELDOFFY=0 -D VELOFFY=1 -D FIELDOFFZ=0 -D VELOFFZ=1 -D ADVECTMETHOD=1
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini  -D FIELDOFFX=0 -D VELOFFX=1 -D FIELDOFFY=0 -D VELOFFY=1 -D FIELDOFFZ=0 -D VELOFFZ=1 -D ADVECTMETHOD=1" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini  -D FIELDOFFX=0 -D VELOFFX=1 -D FIELDOFFY=0 -D VELOFFY=1 -D FIELDOFFZ=0 -D VELOFFZ=1 -D ADVECTMETHOD=1" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/analysis.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/analysis.cl
@@ -323,4 +323,4 @@ crossProductAligned(__global const float *u,
 
 
 // buildOptions=-D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/gridops.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/gridops.cl
@@ -510,4 +510,4 @@ boxFilterWindow(__global const float *src,
 
 
 // buildOptions=-D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/linearcombination.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Houdini/linearcombination.cl
@@ -215,4 +215,4 @@ linearCombination3(float c0, __global const float *a0,
 
 
 // buildOptions=-D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini -D NFIELDS=2 -D USECONST=1 -D MIXOP=1 -D OFFSET0=0 -D OFFSET1=-1
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini -D NFIELDS=2 -D USECONST=1 -D MIXOP=1 -D OFFSET0=0 -D OFFSET1=-1" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -D NO_DOUBLE_SUPPORT -I testsuite/ocl/AppKernels/Houdini -D NFIELDS=2 -D USECONST=1 -D MIXOP=1 -D OFFSET0=0 -D OFFSET1=-1" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Mathematica/implicit_kernel.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Mathematica/implicit_kernel.cl
@@ -372,4 +372,4 @@ __kernel void IsosurfaceGPU(
 
 
 // buildOptions=-Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D BOUNDING_RADIUS_2=0.3
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D BOUNDING_RADIUS_2=0.3" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D BOUNDING_RADIUS_2=0.3" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Rodinia/heartWall_program_1_0.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Rodinia/heartWall_program_1_0.cl
@@ -1,5 +1,5 @@
 // buildOptions=-Itestsuite/ocl/AppKernels/Rodinia
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/Rodinia" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/Rodinia" %cfg_path --cl-device=%cl_device 2>&1
 
 //========================================================================================================================================================================================================200
 //	DEFINE / INCLUDE

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/Rodinia/srad_program_1_0.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/Rodinia/srad_program_1_0.cl
@@ -342,4 +342,4 @@ compress_kernel(long d_Ne,
 
 
 // buildOptions=-Itestsuite/ocl/AppKernels/Rodinia
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/Rodinia" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/Rodinia" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/SmallptGPU/rendering_kernel.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/SmallptGPU/rendering_kernel.cl
@@ -98,4 +98,4 @@ __kernel void RadianceGPU(
 
 
 // buildOptions=-Itestsuite/ocl/AppKernels/SmallptGPU
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/SmallptGPU" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/SmallptGPU" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/SmallptGPU/rendering_kernel_dl.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/SmallptGPU/rendering_kernel_dl.cl
@@ -98,4 +98,4 @@ __kernel void RadianceGPU(
 
 
 // buildOptions=-Itestsuite/ocl/AppKernels/SmallptGPU
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/SmallptGPU" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/SmallptGPU" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/AppKernels/ocl_nvidia_samples/matrixMul.cl
+++ b/tests/c99_kernels/testsuite/ocl/AppKernels/ocl_nvidia_samples/matrixMul.cl
@@ -90,4 +90,4 @@ matrixMul( __global float* C, __global float* A, __global float* B,
 
 
 // buildOptions=-I testsuite/ocl/AppKernels/ocl_nvidia_samples
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -I testsuite/ocl/AppKernels/ocl_nvidia_samples" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -I testsuite/ocl/AppKernels/ocl_nvidia_samples" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/hsd/5055854/VCA.cl
+++ b/tests/c99_kernels/testsuite/ocl/hsd/5055854/VCA.cl
@@ -196,4 +196,4 @@ void dspp_read_block_8u_wg(
 
 
 // buildOptions= -I testsuite/ocl/hsd/5055854
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S  -I testsuite/ocl/hsd/5055854" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S  -I testsuite/ocl/hsd/5055854" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite/ocl/hsd/5059075/FixedFilter.cl
+++ b/tests/c99_kernels/testsuite/ocl/hsd/5059075/FixedFilter.cl
@@ -633,4 +633,4 @@ void clpp_filter_fixed_3x3_8u16s_wg(
 
 
 // buildOptions= -I testsuite/ocl/hsd/5059075 -DBLK_X=128 -DBLK_Y=8
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S  -I testsuite/ocl/hsd/5059075 -DBLK_X=128 -DBLK_Y=8" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S  -I testsuite/ocl/hsd/5059075 -DBLK_X=128 -DBLK_Y=8" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite_double/ocl/AppKernels/Mathematica/Mandelbulb_kernel.cl
+++ b/tests/c99_kernels/testsuite_double/ocl/AppKernels/Mathematica/Mandelbulb_kernel.cl
@@ -348,4 +348,4 @@ __kernel void MandelbulbGPU(
 
 
 // buildOptions=-Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D COLOR_R=100 -D COLOR_G=100 -D COLOR_B=100 -D ENABLE_SHADOW=1
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D COLOR_R=100 -D COLOR_G=100 -D COLOR_B=100 -D ENABLE_SHADOW=1" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D COLOR_R=100 -D COLOR_G=100 -D COLOR_B=100 -D ENABLE_SHADOW=1" %cfg_path --cl-device=%cl_device 2>&1

--- a/tests/c99_kernels/testsuite_double/ocl/AppKernels/Mathematica/fractal_kernel.cl
+++ b/tests/c99_kernels/testsuite_double/ocl/AppKernels/Mathematica/fractal_kernel.cl
@@ -349,4 +349,4 @@ __kernel void MandelbulbGPU(
 
 
 // buildOptions=-Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D COLOR_R=100 -D COLOR_G=100 -D COLOR_B=100 -D ENABLE_SHADOW=1
-// RUN: %occ-cli %s --cl-options="-I%cwd -I%S -Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D COLOR_R=100 -D COLOR_G=100 -D COLOR_B=100 -D ENABLE_SHADOW=1" %cfg_path --cl-device=%cl_device 2>&1
+// RUN: %occ-cli %s --cl-options="-I%cwd -I%/S -Itestsuite/ocl/AppKernels/Mathematica -D FLOOR_POSITION=1 -D COLOR_R=100 -D COLOR_G=100 -D COLOR_B=100 -D ENABLE_SHADOW=1" %cfg_path --cl-device=%cl_device 2>&1


### PR DESCRIPTION
1, s-option.cl:  the first check is not supported on Windows. 2, for other changes under c99_kernels folder:
     "%S" expands to the directory containing the current test file.
          for example:  C:\llvm\test\ (Windows) or /home/user/llvm/test/ (Linux)
     "%/S" same as %S, but forces forward slashes (/) in the path

   This tests are executed on Linux or Linux shell on windows.