### PR TITLE
[ocl-open-150] Fix quoted_tokenize escape handling dropping backslash (#842)

### DIFF
--- a/options.h
+++ b/options.h
@@ -221,38 +221,33 @@ void quoted_tokenize(OutIt dest, llvm::StringRef str, llvm::StringRef delims,
   // pArg state machine, with the following state vars:
   //
   // ptr        - points to the current char in the string
-  // is_escaped - is the current char escaped (i.e. was the
-  //              previous char = escape, inside a quote)
   // in_quote   - are we in a quote now (i.e. a quote character
   //              appeared without a matching closing quote)
   // tok        - accumulates the current token. once an unquoted
   //              delimiter or end of string is encountered, tok
   //              is added to the return vector and re-initialized
   //
-  bool is_escaped = false;
+  // The escape char only escapes the quote, the escape char itself,
+  // or a delimiter - it is otherwise passed through verbatim, so
+  // that arbitrary text (e.g. "\n" inside a macro value, or Windows
+  // paths) isn't corrupted.
+  //
   bool in_quote = false;
   std::string tok;
 
   while (ptr < end) {
     char c = str[ptr];
-    if (c == escape) {
-      if (is_escaped) {
-        tok += c;
-        is_escaped = false;
-      } else {
-        is_escaped = true;
-      }
+    if (c == escape && ptr + 1 < end &&
+        (str[ptr + 1] == quote || str[ptr + 1] == escape ||
+         delims.find(str[ptr + 1]) != llvm::StringRef::npos)) {
+      tok += str[ptr + 1];
+      ptr += 2;
+      continue;
     } else if (c == quote) {
-      if (is_escaped) {
-        tok += c;
-        is_escaped = false;
-      } else {
-        in_quote = in_quote ? false : true;
-      }
+      in_quote = in_quote ? false : true;
     } else if (delims.find(c) != llvm::StringRef::npos) {
-      if (is_escaped || in_quote) {
+      if (in_quote) {
         tok += c;
-        is_escaped = false;
       } else {
         *(dest++) = tok;
         tok.clear();
@@ -264,7 +259,6 @@ void quoted_tokenize(OutIt dest, llvm::StringRef str, llvm::StringRef delims,
         }
       }
     } else {
-      is_escaped = false;
       tok += c;
     }
     ++ptr;

--- a/tests/Manual/testsuite/backslash-escape-option.cl
+++ b/tests/Manual/testsuite/backslash-escape-option.cl
@@ -1,0 +1,17 @@
+// RUN: %occ-cli %s --cl-options="-DTYPE=int -DSTRING=\"%d\\n\"" --cl-device=%cl_device %cfg_path --output=%t.bc
+// RUN: llvm-dis < %t.bc | FileCheck %s
+
+// Regression test: quoted_tokenize() must not drop a backslash that
+// does not escape a quote, itself, or a delimiter. A macro value such
+// as "%d\n" was previously tokenized to "%dn", losing the newline.
+
+// CHECK: @.str = {{.*}}constant {{.*}} c"%d\0A\00"
+
+#define AS_STRING(s) AS_STRING_(s)
+#define AS_STRING_(s) #s
+
+kernel void test_printf_arguments(global const TYPE *input) {
+  const int gid = get_global_id(0);
+  TYPE i = input[gid];
+  printf(AS_STRING(STRING), i);
+}


### PR DESCRIPTION
The escape-state-machine rewrite always consumed the backslash before an escaped char without re-emitting it, so any backslash not itself escaped (e.g. \n, \t, or Windows path separators) was silently stripped from -D macro values and other options. Restore backslash pass-through by only consuming it via one-char lookahead when it actually escapes the quote char, itself, or a delimiter.

Add regression test for backslash escape handling in cl-options: Covers the printf(%d\n) style corruption where quoted_tokenize() dropped a backslash that didn't escape the quote/escape/delimiter chars, e.g. -DSTRING="%d\n" became "%dn".

(cherry picked from commit 55616bd15e4df8a98c12a35928ff9561b0385fd7)