### PR TITLE
Delete backport branch after its PR is merged

### DIFF
--- a/.github/workflows/backport-to-branch.yml
+++ b/.github/workflows/backport-to-branch.yml
@@ -4,6 +4,8 @@ name: Backport on Comment
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -13,6 +15,7 @@ permissions:
 jobs:
   backport:
     if: >
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/backport ')
     runs-on: ubuntu-latest
@@ -184,3 +187,25 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: backport-complete
+
+  delete-backport-branch:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'backport/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Delete backport branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const ref = context.payload.pull_request.head.ref;
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${ref}`
+            });


### PR DESCRIPTION
Adds a pull_request(closed) trigger that removes the backport/* head branch once the auto-created backport PR is merged.