### PR TITLE
Fix -Wunused-result warning in occ-cli main.cpp

### DIFF
--- a/tests/occ-cli/main.cpp
+++ b/tests/occ-cli/main.cpp
@@ -38,14 +38,14 @@ int main(int argc, char *argv[]) {
     }
 
     string method = "compile";
-    find_if(args.begin(), args.end(), [&](const string &s) {
+    for (const string &s : args) {
       string methodParam = "--method=";
       auto it = s.find(methodParam);
       if (it != string::npos) {
         method.assign(s.begin() + it + methodParam.size(), s.end());
+        break;
       }
-      return it != string::npos;
-    });
+    }
 
     transform(method.begin(), method.end(), method.begin(), ::tolower);
 


### PR DESCRIPTION
Replace find_if with a range-based for loop since the code only needs the early-exit side effect, not the returned iterator, avoiding the nodiscard warning on find_if's return value.