### PR TITLE
Add delete-backport-branch workflow to ocl-open-200

### DIFF
--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -1,0 +1,27 @@
+name: Delete backport branch
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-backport-branch:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'backport/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete backport branch
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const ref = context.payload.pull_request.head.ref;
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${ref}`
+            });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/delete-backport-branch.yml`, a minimal workflow that deletes a `backport/*` head branch once its PR is merged into ocl-open-200.
- On `main`, this same behavior is bundled into `backport-to-branch.yml` (added by #843 / #855), but GitHub reads `pull_request`-triggered workflows from the PR's *base* branch, not `main`. Since `backport-to-branch.yml` doesn't exist on ocl-open-200, backport branches merged here were never auto-deleted (see backport/pr-865-to-ocl-open-230 lingering after #866 merged).
- This adds only the delete job, not the `/backport` comment-triggered automation from main, since that's driven from main against open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)