### PR TITLE
Require clang for CL3.1 probe in prebuilt-LLVM build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # A prebuilt clang may predate the CL3.1 patches carried in patches/clang
     # (only applied when building clang from source, see below). Probe it so
     # we don't try to generate a PCM with a -cl-std value the compiler rejects.
-    find_program(OPENCL_CLANG_PROBE_CLANG clang PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+    find_program(OPENCL_CLANG_PROBE_CLANG clang PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH REQUIRED)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cl31_check.cl" "")
     execute_process(
         COMMAND ${OPENCL_CLANG_PROBE_CLANG} -cl-std=CL3.1 -x cl -fsyntax-only "${CMAKE_CURRENT_BINARY_DIR}/cl31_check.cl"

--- a/cl_headers/CMakeLists.txt
+++ b/cl_headers/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CL_HEADERS_LIB cl_headers)
 if(USE_PREBUILT_LLVM)
-    find_program(CLANG_COMMAND clang PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+    set(CLANG_COMMAND ${OPENCL_CLANG_PROBE_CLANG})
 else()
     set(CLANG_COMMAND $<TARGET_FILE:clang>)
 endif()


### PR DESCRIPTION
clang is a hard dependency of the prebuilt-LLVM build: cl_headers needs it to generate the OpenCL C PCMs that are linked directly into opencl-clang. Without REQUIRED, a missing clang silently degraded to skipping CL3.1 PCM support instead of failing configure immediately.

Since the probe now guarantees clang exists, reuse OPENCL_CLANG_PROBE_CLANG as cl_headers' CLANG_COMMAND instead of running find_program a second time for the same binary.