### PR TITLE
Simplify LLVMSPIRVLib include after upstream PUBLIC include export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,8 @@ if(NOT USE_PREBUILT_LLVM)
     set(CLANG_BINARY_DIR ${LLVM_BINARY_DIR}/tools/clang/)
     include_directories(
         ${CLANG_BINARY_DIR}/include  # for tablegened includes
-        ${CLANG_SOURCE_DIR}/include  # for basic headers
-        ${SPIRV_SOURCE_DIR}/include) # for SPIRV headers
+        ${CLANG_SOURCE_DIR}/include) # for basic headers
+    # SPIRV headers are picked up transitively via the LLVMSPIRVLib target.
 endif(NOT USE_PREBUILT_LLVM)
 
 if(USE_PREBUILT_LLVM AND NOT LLVMSPIRV_INCLUDED_IN_LLVM)


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/ab0c969d marks LLVMSPIRVLib's target_include_directories as PUBLIC, so its include directory is now propagated transitively through the LLVMSPIRVLib CMake target in the in-tree build. Drop the now-redundant manual include_directories() entry for SPIRV_SOURCE_DIR/include.